### PR TITLE
Skip persisting workflow elements if they didn't change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Fixed
-- #47 Changes to the step and workflow are now persisted before publishing events.
+1. #47 Changes to the step and workflow are now persisted before publishing events.
 ### Changed
-- Harmonized Spring Boot dependencies
-- The Spring packages are now targeting version 3.2.1
+1. Harmonized Spring Boot dependencies
+2. The Spring packages are now targeting version 3.2.1
 ### Removed
 
 ## [0.0.1] - 2024-01-24
 
 ### Added
-- Initial FluxFlow release
+1.~~~~ Initial FluxFlow release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
+
 ### Fixed
-1. #47 Changes to the step and workflow are now persisted before publishing events.
+1. Changes to the step and workflow are now persisted before publishing events. [Issue #47](https://github.com/lisegmbh/fluxflow/issues/47)
+2. Persisting and publishing of step and workflow updates are now skipped, if the element didn't actually change. Can be disabled by setting `fluxflow.change-detection.step` or `fluxflow.change-detection.workflow` to `false`. [Issue #49](https://github.com/lisegmbh/fluxflow/issues/49)
+
 ### Changed
-1. Harmonized Spring Boot dependencies
-2. The Spring packages are now targeting version 3.2.1
+1. Harmonized Spring Boot dependencies.
+2. The Spring packages are now targeting version 3.2.1.
+
 ### Removed
 
 ## [0.0.1] - 2024-01-24
 
 ### Added
-1.~~~~ Initial FluxFlow release
+1. Initial FluxFlow release

--- a/library/api/src/main/kotlin/de/lise/fluxflow/api/state/ChangeDetector.kt
+++ b/library/api/src/main/kotlin/de/lise/fluxflow/api/state/ChangeDetector.kt
@@ -1,0 +1,15 @@
+package de.lise.fluxflow.api.state
+
+/**
+ * The [ChangeDetector] is responsible for detecting, if two versions of the same entity have changed.
+ * @param TEntity The entity that can be tracked by this detector.
+ */
+fun interface ChangeDetector<in TEntity> {
+    /**
+     * Checks if the provided representations of a given entity are different from each other.
+     * @param oldVersion The entity's older representation/state.
+     * @param newVersion The entity's newer representation/state.
+     * @return `true`, if the new version differs from the old version.
+     */
+    fun hasChanged(oldVersion: TEntity, newVersion: TEntity): Boolean
+}

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.0.2-SNAPSHOT-3"
+    version = projVersion ?: "0.1.0-SNAPSHOT"
 
     repositories {
         mavenCentral()

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.0.2-SNAPSHOT-2"
+    version = projVersion ?: "0.0.2-SNAPSHOT-3"
 
     repositories {
         mavenCentral()

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/BeforeWorkflowUpdateEvent.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/BeforeWorkflowUpdateEvent.kt
@@ -2,4 +2,14 @@ package de.lise.fluxflow.engine.event.workflow
 
 import de.lise.fluxflow.api.workflow.Workflow
 
+/**
+ * This event is raised immediately whenever FluxFlow is requested to persist changes to a workflow.
+ * 
+ * **Important**:
+ * The event will be raised unconditionally every time a persist operation is **requested**.
+ * This holds true,
+ * even if FluxFlow later determines
+ * that the persist operation can be skipped because the workflow didn't really change.
+ */
+@Deprecated("This event will not be raised in future versions of FluxFlow and is going to be removed.")
 class BeforeWorkflowUpdateEvent(workflow: Workflow<*>): WorkflowEvent(workflow)

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualityChecker.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualityChecker.kt
@@ -1,0 +1,23 @@
+package de.lise.fluxflow.engine.reflection
+
+typealias JavaEqualityChecker<TElement> = EqualityChecker<TElement, Any?>
+
+fun interface EqualityChecker<in TElement, in TOther> {
+    fun checkIfEqual(instance: TElement, other: TOther): Boolean
+
+    infix fun <TNewElement : TElement, TNewOther: TOther> and(
+        checker: EqualityChecker<TNewElement, TNewOther>
+    ): EqualityChecker<TNewElement, TNewOther> {
+        return EqualityChecker { instance, other ->
+            checkIfEqual(instance, other) && checker.checkIfEqual(instance, other)
+        }
+    }
+
+    companion object {
+        fun <TElement, TOther> alwaysEqual(): EqualityChecker<TElement, TOther> {
+            return EqualityChecker { _, _ ->
+                true
+            }
+        }
+    }
+}

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCode.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCode.kt
@@ -6,7 +6,6 @@ data class EqualsAndHashCode<in TElement>(
     val equalityChecker: JavaEqualityChecker<TElement>,
     val hashCodeComposer: HashComposer<TElement>
 ) {
-
     fun areEqual(instance: TElement, other: Any?): Boolean {
         return equalityChecker.checkIfEqual(instance, other)
     }
@@ -19,7 +18,7 @@ data class EqualsAndHashCode<in TElement>(
         @JvmStatic
         fun <TElement : Any> forType(
             type: KClass<TElement>,
-            makeAccessible: Boolean = false
+            makeAccessible: Boolean = true
         ): EqualsAndHashCode<TElement> {
             return EqualsAndHashCodeBuilder(
                 type,
@@ -29,7 +28,7 @@ data class EqualsAndHashCode<in TElement>(
 
         @JvmStatic
         inline fun <reified TElement : Any> forType(
-            makeAccessible: Boolean = false
+            makeAccessible: Boolean = true
         ): EqualsAndHashCode<TElement> {
             return forType(TElement::class, makeAccessible)
         }

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCode.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCode.kt
@@ -1,0 +1,37 @@
+package de.lise.fluxflow.engine.reflection
+
+import kotlin.reflect.KClass
+
+data class EqualsAndHashCode<in TElement>(
+    val equalityChecker: JavaEqualityChecker<TElement>,
+    val hashCodeComposer: HashComposer<TElement>
+) {
+
+    fun areEqual(instance: TElement, other: Any?): Boolean {
+        return equalityChecker.checkIfEqual(instance, other)
+    }
+
+    fun composeHash(instance: TElement): Int {
+        return hashCodeComposer.composeHashCode(instance)
+    }
+
+    companion object {
+        @JvmStatic
+        fun <TElement : Any> forType(
+            type: KClass<TElement>,
+            makeAccessible: Boolean = false
+        ): EqualsAndHashCode<TElement> {
+            return EqualsAndHashCodeBuilder(
+                type,
+                makeAccessible = makeAccessible
+            ).build()
+        }
+
+        @JvmStatic
+        inline fun <reified TElement : Any> forType(
+            makeAccessible: Boolean = false
+        ): EqualsAndHashCode<TElement> {
+            return forType(TElement::class, makeAccessible)
+        }
+    }
+}

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilder.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilder.kt
@@ -1,0 +1,89 @@
+package de.lise.fluxflow.engine.reflection
+
+import kotlin.reflect.*
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+typealias PropertyMap<TElement> = Map<KProperty1<TElement, *>, (element: TElement) -> Any?>
+
+class EqualsAndHashCodeBuilder<TElement : Any>(
+    private val type: KClass<TElement>,
+    private val strictTypeCheck: Boolean = true,
+    private val makeAccessible: Boolean = false
+) {
+    fun build(): EqualsAndHashCode<TElement> {
+        val propertyGetters = buildPropertyGetters()
+        val propertyEqualityChecker = buildPropertyChecker(propertyGetters)
+
+        val equalityChecker: JavaEqualityChecker<TElement> = when(strictTypeCheck) {
+            true -> JavaEqualityChecker { instance, other ->
+                when(val castedOther = other?.let { type.safeCast(it) }) {
+                    null -> false
+                    else -> propertyEqualityChecker.checkIfEqual(instance, castedOther)
+                }
+            }
+            else -> JavaEqualityChecker { instance, other ->
+                when(other?.let { it::class }) {
+                    type -> propertyEqualityChecker.checkIfEqual(instance, type.cast(other))
+                    else -> false
+                }
+            }
+        }
+
+        val hashCodeComposer = buildHashCodeComposer(propertyGetters)
+
+        return EqualsAndHashCode(
+            equalityChecker,
+            hashCodeComposer
+        )
+    }
+
+
+    private fun buildPropertyGetters(): PropertyMap<TElement> {
+        val relevantProperties = type.memberProperties
+            .filter {
+                it.visibility == KVisibility.PUBLIC
+            }.mapNotNull {
+                when(it.isAccessible) {
+                    true -> it
+                    false -> when(makeAccessible) {
+                        true -> it.apply { it.isAccessible = true }
+                        else -> null
+                    }
+                }
+            }
+
+        return relevantProperties.associateWith { property ->
+            { instance ->
+                property.get(instance)
+            }
+        }
+    }
+
+    private fun buildHashCodeComposer(
+        propertyGetters: PropertyMap<TElement>
+    ): HashComposer<TElement> {
+        return propertyGetters.values.map { getter ->
+            HashComposer<TElement> { instance ->
+                getter(instance)?.hashCode() ?: 0
+            }
+        }.reduceOrNull { acc, hashComposer ->
+            acc and hashComposer
+        } ?: HashComposer { 0 }
+    }
+
+    private fun buildPropertyChecker(
+        propertyGetters: PropertyMap<TElement>
+    ): EqualityChecker<TElement, TElement?> {
+        return propertyGetters.values.map { getter ->
+            EqualityChecker<TElement, TElement?> { instance, other ->
+                when(other) {
+                    null -> false
+                    else -> getter(instance) == getter(other)
+                }
+            }
+        }.reduceOrNull { acc, equalityChecker ->
+            acc and equalityChecker
+        } ?: EqualityChecker.alwaysEqual()
+    }
+}

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilder.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilder.kt
@@ -9,7 +9,7 @@ typealias PropertyMap<TElement> = Map<KProperty1<TElement, *>, (element: TElemen
 class EqualsAndHashCodeBuilder<TElement : Any>(
     private val type: KClass<TElement>,
     private val strictTypeCheck: Boolean = true,
-    private val makeAccessible: Boolean = false
+    private val makeAccessible: Boolean = true
 ) {
     fun build(): EqualsAndHashCode<TElement> {
         val propertyGetters = buildPropertyGetters()

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/HashComposer.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/reflection/HashComposer.kt
@@ -1,0 +1,11 @@
+package de.lise.fluxflow.engine.reflection
+
+fun interface HashComposer<in TElement> {
+    fun composeHashCode(element: TElement): Int
+
+    infix fun <TOther : TElement> and(other: HashComposer<TOther>): HashComposer<TOther> {
+        return HashComposer { instance ->
+            composeHashCode(instance) xor other.composeHashCode(instance)
+        }
+    }
+}

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/state/AssumingChangeDetector.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/state/AssumingChangeDetector.kt
@@ -1,0 +1,15 @@
+package de.lise.fluxflow.engine.state
+
+import de.lise.fluxflow.api.state.ChangeDetector
+
+/**
+ * The [AssumingChangeDetector] always assumes that an entity did change if [assumedResult] is set to `true`.
+ * If it is set to `false`, it always assumes that it did not change.
+ */
+class AssumingChangeDetector<in TEntity>(
+    private val assumedResult: Boolean
+): ChangeDetector<TEntity> {
+    override fun hasChanged(oldVersion: TEntity, newVersion: TEntity): Boolean {
+        return assumedResult
+    }
+}

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/state/DefaultChangeDetector.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/state/DefaultChangeDetector.kt
@@ -1,0 +1,13 @@
+package de.lise.fluxflow.engine.state
+
+import de.lise.fluxflow.api.state.ChangeDetector
+
+class DefaultChangeDetector<in TEntity> : ChangeDetector<TEntity> {
+    override fun hasChanged(
+        oldVersion: TEntity,
+        newVersion: TEntity
+    ): Boolean {
+        return oldVersion != newVersion
+    }
+}
+

--- a/library/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowUpdateServiceImpl.kt
+++ b/library/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowUpdateServiceImpl.kt
@@ -1,24 +1,38 @@
 package de.lise.fluxflow.engine.workflow
 
 import de.lise.fluxflow.api.event.EventService
+import de.lise.fluxflow.api.state.ChangeDetector
 import de.lise.fluxflow.api.workflow.Workflow
 import de.lise.fluxflow.api.workflow.WorkflowUpdateService
 import de.lise.fluxflow.engine.event.workflow.BeforeWorkflowUpdateEvent
 import de.lise.fluxflow.engine.event.workflow.WorkflowUpdatedEvent
+import de.lise.fluxflow.persistence.workflow.WorkflowData
 import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
+import org.slf4j.LoggerFactory
 
 class WorkflowUpdateServiceImpl(
     private val persistence: WorkflowPersistence,
+    private val changeDetector: ChangeDetector<WorkflowData>,
     private val eventService: EventService,
 ) : WorkflowUpdateService {
     override fun <TWorkflowModel> saveChanges(workflow: Workflow<TWorkflowModel>): Workflow<TWorkflowModel> {
         eventService.publish(BeforeWorkflowUpdateEvent(workflow))
 
-        val data = persistence.find(workflow.id)!!
-        val updatedWorkflow = persistence.save(data.withModel(workflow.model))
+        val oldWorkflowData = persistence.find(workflow.id)!!
+        val updatedWorkflowData = oldWorkflowData.withModel(workflow.model)
+        if(!changeDetector.hasChanged(oldWorkflowData, updatedWorkflowData)) {
+            Logger.debug("Skip persisting/updating workflow '{}' as it hasn't changed.", workflow.id.value)
+            return workflow
+        }
+        
+        val updatedWorkflow = persistence.save(updatedWorkflowData)
 
         eventService.publish(WorkflowUpdatedEvent(workflow))
 
         return WorkflowImpl(updatedWorkflow)
+    }
+    
+    private companion object {
+        private val Logger = LoggerFactory.getLogger(WorkflowStarterServiceImpl::class.java)!! 
     }
 }

--- a/library/engine/src/test/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilderTest.kt
+++ b/library/engine/src/test/kotlin/de/lise/fluxflow/engine/reflection/EqualsAndHashCodeBuilderTest.kt
@@ -1,0 +1,100 @@
+package de.lise.fluxflow.engine.reflection
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class EqualsAndHashCodeBuilderTest {
+    @Test
+    fun `objects without properties should be considered equal`() {
+        // Arrange
+        val object1 = EmptyModel()
+        val object2 = EmptyModel()
+        val equalsAndHashCode = EqualsAndHashCode.forType<EmptyModel>()
+
+        // Act
+        val areEqual = equalsAndHashCode.areEqual(object1, object2)
+
+        // Assert
+        assertThat(areEqual).isTrue()
+    }
+
+    @Test
+    fun `objects without properties should always produce the same hash`() {
+        // Arrange
+        val object1 = EmptyModel()
+        val object2 = EmptyModel()
+        val equalsAndHashCode = EqualsAndHashCode.forType<EmptyModel>()
+
+        // Act
+        val hash1 = equalsAndHashCode.composeHash(object1)
+        val hash2 = equalsAndHashCode.composeHash(object2)
+
+        // Assert
+        assertThat(hash1).isEqualTo(hash2)
+    }
+
+    @Test
+    fun `objects having the same properties should be considered equal`() {
+        // Arrange
+        val object1 = ModelWithProps("a", 1, null)
+        val object2 = ModelWithProps("a", 1, null)
+        val equalsAndHashCode = EqualsAndHashCode.forType<ModelWithProps>(true)
+
+        // Act
+        val areEqual = equalsAndHashCode.areEqual(object1, object2)
+
+        // Assert
+        assertThat(areEqual).isTrue()
+    }
+
+    @Test
+    fun `objects having the same properties should produce the same hash`() {
+        // Arrange
+        val object1 = ModelWithProps("a", 1, null)
+        val object2 = ModelWithProps("a", 1, null)
+        val equalsAndHashCode = EqualsAndHashCode.forType<ModelWithProps>(true)
+
+        // Act
+        val hash1 = equalsAndHashCode.composeHash(object1)
+        val hash2 = equalsAndHashCode.composeHash(object2)
+
+        // Assert
+        assertThat(hash1).isEqualTo(hash2)
+    }
+
+    @Test
+    fun `objects having different properties should be considered different`() {
+        // Arrange
+        val object1 = ModelWithProps("a", 1, null)
+        val object2 = ModelWithProps("a", 2, null)
+        val equalsAndHashCode = EqualsAndHashCode.forType<ModelWithProps>(true)
+
+        // Act
+        val areEqual = equalsAndHashCode.areEqual(object1, object2)
+
+        // Assert
+        assertThat(areEqual).isFalse()
+    }
+
+    @Test
+    fun `objects having different properties should produce different hashes`() {
+        // Arrange
+        val object1 = ModelWithProps("a", 1, null)
+        val object2 = ModelWithProps("b", 1, null)
+        val equalsAndHashCode = EqualsAndHashCode.forType<ModelWithProps>(true)
+
+        // Act
+        val hash1 = equalsAndHashCode.composeHash(object1)
+        val hash2 = equalsAndHashCode.composeHash(object2)
+
+        // Assert
+        assertThat(hash1).isNotEqualTo(hash2)
+    }
+
+    private class EmptyModel
+    private class ModelWithProps(
+        val someProperty: String,
+        val anotherProperty: Int,
+        val complexProperty: Any?
+    )
+}

--- a/library/engine/src/test/kotlin/de/lise/fluxflow/engine/state/AssumingChangeDetectorTest.kt
+++ b/library/engine/src/test/kotlin/de/lise/fluxflow/engine/state/AssumingChangeDetectorTest.kt
@@ -1,0 +1,38 @@
+package de.lise.fluxflow.engine.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AssumingChangeDetectorTest {
+    @Test
+    fun `hasChanged should always return true if assumed result is true`() {
+        // Arrange
+        val changeDetector = AssumingChangeDetector<Any?>(true)
+        val element = Any()
+        val other = Any()
+
+        // Act
+        val equalElementsResult = changeDetector.hasChanged(element, element)
+        val differentElementsResult = changeDetector.hasChanged(element, other)
+
+        // Assert
+        assertThat(equalElementsResult).isTrue()
+        assertThat(differentElementsResult).isTrue()
+    }
+
+    @Test
+    fun `hasChanged should always return false if assumed result is false`() {
+        // Arrange
+        val changeDetector = AssumingChangeDetector<Any?>(false)
+        val element = Any()
+        val other = Any()
+
+        // Act
+        val equalElementsResult = changeDetector.hasChanged(element, element)
+        val differentElementsResult = changeDetector.hasChanged(element, other)
+
+        // Assert
+        assertThat(equalElementsResult).isFalse()
+        assertThat(differentElementsResult).isFalse()
+    }
+}

--- a/library/engine/src/test/kotlin/de/lise/fluxflow/engine/state/DefaultChangeDetectorTest.kt
+++ b/library/engine/src/test/kotlin/de/lise/fluxflow/engine/state/DefaultChangeDetectorTest.kt
@@ -1,0 +1,45 @@
+package de.lise.fluxflow.engine.state
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DefaultChangeDetectorTest {
+    @Test
+    fun `hasChanged should use the objects equality to determine if an object has changed`() {
+        // Arrange
+        val equalOther = Any()
+        val unequalOther = Any()
+        val element = TestObject(equalOther)
+        val changeDetector = DefaultChangeDetector<Any>()
+
+        // Act & Assert
+        val equalElementsResult = changeDetector.hasChanged(element, equalOther)
+        assertThat(equalElementsResult).isFalse()
+        assertThat(element.hasBeenComparedTo).containsExactly(equalOther)
+        element.clear()
+
+        val unequalElementsResult = changeDetector.hasChanged(element, unequalOther)
+        assertThat(unequalElementsResult).isTrue()
+        assertThat(element.hasBeenComparedTo).containsExactly(unequalOther)
+    }
+
+    @Suppress("EqualsOrHashCode")
+    private class TestObject (
+        private val expectedEqual: Any
+    ){
+
+        val hasBeenComparedTo: MutableList<Any?> = mutableListOf()
+
+        fun clear() {
+            hasBeenComparedTo.clear()
+        }
+
+        override fun equals(other: Any?): Boolean {
+            hasBeenComparedTo.add(other)
+            if(other === expectedEqual) {
+                return true
+            }
+            return super.equals(other)
+        }
+    }
+}

--- a/library/engine/src/test/kotlin/de/lise/fluxflow/engine/workflow/WorkflowUpdateServiceImplTest.kt
+++ b/library/engine/src/test/kotlin/de/lise/fluxflow/engine/workflow/WorkflowUpdateServiceImplTest.kt
@@ -1,0 +1,49 @@
+package de.lise.fluxflow.engine.workflow
+
+import de.lise.fluxflow.api.event.EventService
+import de.lise.fluxflow.api.state.ChangeDetector
+import de.lise.fluxflow.api.workflow.Workflow
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.engine.event.workflow.WorkflowUpdatedEvent
+import de.lise.fluxflow.persistence.workflow.WorkflowData
+import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+
+class WorkflowUpdateServiceImplTest {
+    @Test
+    fun `workflows that didn't change should not be persisted`() {
+        // Arrange
+        val testId = WorkflowIdentifier("test")
+        val testModel = Any()
+        val oldWorkflowData = WorkflowData(testId.value, testModel)
+        val workflowPersistence = mock<WorkflowPersistence> {
+            on { find(eq(testId)) } doReturn oldWorkflowData
+        }
+
+        val changeDetector = mock<ChangeDetector<WorkflowData>> {
+            on { hasChanged(any(), any()) } doReturn false
+        }
+        val eventService = mock<EventService> {}
+
+        val workflowUpdateService = WorkflowUpdateServiceImpl(
+            workflowPersistence,
+            changeDetector,
+            eventService
+        )
+
+        val workflow = mock<Workflow<Any>> {
+            on { id } doReturn testId
+            on { model } doReturn testModel
+        }
+
+        // Act
+        workflowUpdateService.saveChanges(workflow)
+
+        // Assert
+        verify(changeDetector, times(1)).hasChanged(any(), any())
+        verify(workflowPersistence, never()).save(any())
+        verify(eventService, never()).publish(any<WorkflowUpdatedEvent>())
+    }
+
+}

--- a/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/EnableFluxFlow.kt
+++ b/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/EnableFluxFlow.kt
@@ -1,8 +1,9 @@
 package de.lise.fluxflow.springboot
 
+import de.lise.fluxflow.springboot.configuration.BasicConfiguration
 import org.springframework.context.annotation.Import
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
-@Import(FluxFlowConfiguration::class)
+@Import(BasicConfiguration::class)
 annotation class EnableFluxFlow

--- a/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
+++ b/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
@@ -1,10 +1,11 @@
-package de.lise.fluxflow.springboot
+package de.lise.fluxflow.springboot.configuration
 
 import de.lise.fluxflow.api.bootstrapping.BootstrapAction
 import de.lise.fluxflow.api.event.EventService
 import de.lise.fluxflow.api.event.FlowListener
 import de.lise.fluxflow.api.ioc.IocProvider
 import de.lise.fluxflow.api.job.JobService
+import de.lise.fluxflow.api.state.ChangeDetector
 import de.lise.fluxflow.api.step.StepService
 import de.lise.fluxflow.api.workflow.WorkflowService
 import de.lise.fluxflow.api.workflow.WorkflowStarterService
@@ -29,6 +30,7 @@ import de.lise.fluxflow.engine.workflow.WorkflowUpdateServiceImpl
 import de.lise.fluxflow.persistence.continuation.history.ContinuationRecordPersistence
 import de.lise.fluxflow.persistence.job.JobPersistence
 import de.lise.fluxflow.persistence.step.StepPersistence
+import de.lise.fluxflow.persistence.workflow.WorkflowData
 import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
 import de.lise.fluxflow.reflection.activation.parameter.*
 import de.lise.fluxflow.scheduling.SchedulingCallback
@@ -63,7 +65,8 @@ import java.time.Clock
 
 @Configuration
 @ComponentScan(basePackages = ["de.lise.fluxflow.springboot.autoconfigure"])
-open class FluxFlowConfiguration {
+@Import(ChangeDetectionConfiguration::class)
+open class BasicConfiguration {
     @Lazy
     @Autowired
     // This needs to be done to avoid the circular dependency between StepServiceImpl and ContinuationService
@@ -114,10 +117,12 @@ open class FluxFlowConfiguration {
     @Bean
     open fun workflowUpdateService(
         persistence: WorkflowPersistence,
+        changeDetector: ChangeDetector<WorkflowData>,
         eventService: EventService
     ): WorkflowUpdateService {
         return WorkflowUpdateServiceImpl(
             persistence,
+            changeDetector,
             eventService
         )
     }

--- a/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
+++ b/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
@@ -29,6 +29,7 @@ import de.lise.fluxflow.engine.workflow.WorkflowStarterServiceImpl
 import de.lise.fluxflow.engine.workflow.WorkflowUpdateServiceImpl
 import de.lise.fluxflow.persistence.continuation.history.ContinuationRecordPersistence
 import de.lise.fluxflow.persistence.job.JobPersistence
+import de.lise.fluxflow.persistence.step.StepData
 import de.lise.fluxflow.persistence.step.StepPersistence
 import de.lise.fluxflow.persistence.workflow.WorkflowData
 import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
@@ -295,13 +296,15 @@ open class BasicConfiguration {
     open fun stepService(
         persistence: StepPersistence,
         stepActivationService: StepActivationService,
-        eventService: EventService
+        eventService: EventService,
+        changeDetector: ChangeDetector<StepData>
     ): StepServiceImpl {
         return StepServiceImpl(
             persistence,
             stepActivationService,
             eventService,
-            continuationService!!
+            continuationService!!,
+            changeDetector
         )
     }
 

--- a/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/ChangeDetectionConfiguration.kt
+++ b/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/ChangeDetectionConfiguration.kt
@@ -3,6 +3,7 @@ package de.lise.fluxflow.springboot.configuration
 import de.lise.fluxflow.api.state.ChangeDetector
 import de.lise.fluxflow.engine.state.AssumingChangeDetector
 import de.lise.fluxflow.engine.state.DefaultChangeDetector
+import de.lise.fluxflow.persistence.step.StepData
 import de.lise.fluxflow.persistence.workflow.WorkflowData
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -12,7 +13,7 @@ import org.springframework.context.annotation.Configuration
 open class ChangeDetectionConfiguration {
     @Bean
     @ConditionalOnProperty(
-        name = ["fluxflow.change-detection.steps"],
+        name = ["fluxflow.change-detection.workflow"],
         havingValue = "true",
         matchIfMissing = true
     )
@@ -23,12 +24,34 @@ open class ChangeDetectionConfiguration {
 
     @Bean
     @ConditionalOnProperty(
-        name = ["fluxflow.change-detection.steps"],
+        name = ["fluxflow.change-detection.workflow"],
         havingValue = "false",
         matchIfMissing = false
     )
     open fun disabledWorkflowDataChangeDetector(
     ): ChangeDetector<WorkflowData> {
+        return AssumingChangeDetector(true)
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fluxflow.change-detection.step"],
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    open fun stepDataChangeDetector(
+    ): ChangeDetector<StepData> {
+        return DefaultChangeDetector()
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fluxflow.change-detection.step"],
+        havingValue = "false",
+        matchIfMissing = false
+    )
+    open fun disabledStepDataChangeDetector(
+    ): ChangeDetector<StepData> {
         return AssumingChangeDetector(true)
     }
 }

--- a/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/ChangeDetectionConfiguration.kt
+++ b/library/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/ChangeDetectionConfiguration.kt
@@ -1,0 +1,34 @@
+package de.lise.fluxflow.springboot.configuration
+
+import de.lise.fluxflow.api.state.ChangeDetector
+import de.lise.fluxflow.engine.state.AssumingChangeDetector
+import de.lise.fluxflow.engine.state.DefaultChangeDetector
+import de.lise.fluxflow.persistence.workflow.WorkflowData
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class ChangeDetectionConfiguration {
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fluxflow.change-detection.steps"],
+        havingValue = "true",
+        matchIfMissing = true
+    )
+    open fun workflowDataChangeDetector(
+    ): ChangeDetector<WorkflowData> {
+        return DefaultChangeDetector()
+    }
+
+    @Bean
+    @ConditionalOnProperty(
+        name = ["fluxflow.change-detection.steps"],
+        havingValue = "false",
+        matchIfMissing = false
+    )
+    open fun disabledWorkflowDataChangeDetector(
+    ): ChangeDetector<WorkflowData> {
+        return AssumingChangeDetector(true)
+    }
+}

--- a/library/testing/src/main/kotlin/de/lise/fluxflow/springboot/testing/TestingConfiguration.kt
+++ b/library/testing/src/main/kotlin/de/lise/fluxflow/springboot/testing/TestingConfiguration.kt
@@ -1,11 +1,13 @@
 package de.lise.fluxflow.springboot.testing
 
-import de.lise.fluxflow.springboot.FluxFlowConfiguration
+import de.lise.fluxflow.springboot.configuration.BasicConfiguration
 import de.lise.fluxflow.springboot.InMemoryPersistenceConfiguration
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 
 @Configuration
-
-@Import(FluxFlowConfiguration::class, InMemoryPersistenceConfiguration::class)
+@Import(
+    BasicConfiguration::class, 
+    InMemoryPersistenceConfiguration::class  
+)
 open class TestingConfiguration


### PR DESCRIPTION
This PR resolves #49 by conditional skipping the persist operations, whenever the added `ChangeDetector` determines that the element to be persisted didn't actually change.