### PR TITLE
Avoid converting between Type, KType, Class and KClass when checking for assignability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    Previously, the standard behavior of a workflow replacement continuation was to replace the steps and jobs of the workflow. [Issue #99](https://github.com/lisegmbh/fluxflow/issues/99)
 ### Deprecated
 ### Fixed
+1. **NPE within ParamMatcher.isAssignable**<br/>
+   The `NullPointerException` that has been thrown within
+   `ParamMatcher.isAssignable` when passing in a generic type has been fixed.
+   [Issue #158](https://github.com/lisegmbh/fluxflow/issues/158)
 ### Removed
+1. Removed the unused `Type.toKClass()` extension function from `de.lise.fluxflow.reflection`.
 
 ## [0.1.0] - 2024-03-10
 ### Added

--- a/library/core/reflection/build.gradle.kts
+++ b/library/core/reflection/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.23")
-
+    implementation("org.apache.commons:commons-lang3:3.14.0")
+    
     implementation(project(":core:api"))
     implementation(kotlin("reflect"))
 }

--- a/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/ReflectionUtils.kt
+++ b/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/ReflectionUtils.kt
@@ -4,7 +4,7 @@ import java.lang.reflect.Type
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
-import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaType
 
 class ReflectionUtils private constructor() {
     companion object {
@@ -16,7 +16,6 @@ class ReflectionUtils private constructor() {
             return prop.returnType.classifier as KClass<TProp>
         }
 
-        @OptIn(ExperimentalStdlibApi::class)
         @JvmStatic
         fun <TObject, TProp : Any> findReturnType(
             prop: KProperty1<out TObject, TProp?>

--- a/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/TypeExtensionFunctions.kt
+++ b/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/TypeExtensionFunctions.kt
@@ -1,8 +1,0 @@
-package de.lise.fluxflow.reflection
-
-import java.lang.reflect.Type
-import kotlin.reflect.KClass
-
-fun Type.toKClass(): KClass<*>? {
-    return (this as? Class<*>)?.kotlin
-}

--- a/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/activation/parameter/ParamMatcherTest.kt
+++ b/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/activation/parameter/ParamMatcherTest.kt
@@ -1,0 +1,70 @@
+package de.lise.fluxflow.reflection.activation.parameter
+
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KFunction
+import kotlin.reflect.jvm.javaType
+
+class ParamMatcherTest {
+    private val someGenericProp: List<String>? = null
+    private fun testFunWithMatchingParam(foo: List<String>?) {}
+    private fun testFunWithNonMatchingParam(foo: List<Int>) {}
+    
+    @Test
+    fun `isAssignableFrom should return a matcher that supports java's generic types`(){
+        // Arrange
+        val someGenericType = ParamMatcherTest::someGenericProp.returnType.javaType
+        
+        val matchingFunction: KFunction<*> = ParamMatcherTest::testFunWithMatchingParam
+        val nonMatchingFunction: KFunction<*> = ParamMatcherTest::testFunWithNonMatchingParam
+        
+        // Act
+        val paramMatcher = ParamMatcher.isAssignableFrom(someGenericType)
+        
+        // Assert
+        val positiveResult = paramMatcher.matches(
+            FunctionParameter(
+                matchingFunction,
+                matchingFunction.parameters[1]
+            )
+        )
+        assertThat(positiveResult).isTrue
+        
+        val negativeResult = paramMatcher.matches(
+            FunctionParameter(
+                nonMatchingFunction,
+                nonMatchingFunction.parameters[1]
+            )
+        )
+        assertThat(negativeResult).isFalse
+    }
+
+    @Test
+    fun `isAssignableFrom should return a matcher that supports kotlin's generic types`(){
+        // Arrange
+        val someGenericType = ParamMatcherTest::someGenericProp.returnType
+
+        val matchingFunction: KFunction<*> = ParamMatcherTest::testFunWithMatchingParam
+        val nonMatchingFunction: KFunction<*> = ParamMatcherTest::testFunWithNonMatchingParam
+
+        // Act
+        val paramMatcher = ParamMatcher.isAssignableFrom(someGenericType)
+
+        // Assert
+        val positiveResult = paramMatcher.matches(
+            FunctionParameter(
+                matchingFunction,
+                matchingFunction.parameters[1]
+            )
+        )
+        assertThat(positiveResult).isTrue
+
+        val negativeResult = paramMatcher.matches(
+            FunctionParameter(
+                nonMatchingFunction,
+                nonMatchingFunction.parameters[1]
+            )
+        )
+        assertThat(negativeResult).isFalse
+    }
+}


### PR DESCRIPTION
Resolves #158 