### PR TITLE
Allow passing additional information when updating step data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    FluxFlow can now check if the current step definition is still compatible with the version that has been used to
    originally create a step to be loaded from persistence.
    If it is incompatible, a restored/historic version of the affected step can be returned.
-   See [https://docs.fluxflow.cloud/see/2](https://docs.fluxflow.cloud/see/2) for more information.  
+   See [https://docs.fluxflow.cloud/see/2](https://docs.fluxflow.cloud/see/2) for more information.
+5. **Allow passing additional information when updating step data**<br />
+   The `StepDataService` now accepts an additional parameter allowing developers to pass additional context information.
    
 
 ### Changed

--- a/docs/steps.md
+++ b/docs/steps.md
@@ -1081,6 +1081,59 @@ metadata can be customized.
 
 ## Using steps
 
+### Assigning step data
+A step's data can be modified using the `StepDataService`.
+Please note that the data itself must be modifiable (= implement the `ModifiableData` interface).
+
+```kotlin
+import de.lise.fluxflow.api.step.stateful.data.Data
+import de.lise.fluxflow.api.step.stateful.data.StepDataService
+import java.time.Instant
+
+class ModificationHistoryService(private val stepDataService: StepDataService) {
+    fun assignLastModifiedDate(data: Data<Instant>) {
+        stepDataService.setValue(data, Instant.now())
+    }
+}
+```
+
+The `setValue()` function also accepts an additional context parameter,
+allowing additional information to be passed along.
+This extra information can be obtained by event listeners (see `FlowListener`) using the `FlowEvent.context` property.
+
+```kotlin
+import de.lise.fluxflow.api.step.stateful.data.Data
+import de.lise.fluxflow.api.step.stateful.data.StepDataService
+import java.time.Instant
+
+/**
+ * Provide additional context information
+ */
+class ModificationHistoryService(private val stepDataService: StepDataService) {
+    fun assignLastModifiedDate(data: Data<Instant>, currentUser: User) {
+        stepDataService.setValue(
+            currentUser,    // context information
+            data,           // data to be updated
+            Instant.now()   // value to be assigned
+        )
+    }
+}
+
+/**
+ * Access additional context information
+ */
+class HistoryService: FlowListener {
+    private val logger = LoggerFactory.getLogger(HistoryService::class.java)
+
+    override fun onFlowEvent(event: FlowEvent) {
+        val modifyingUser = event.context as? User
+        if (modifyingUser != null) {
+            logger.debug("Workflow updated by user: {}", modifyingUser)
+        }
+    }
+}
+```
+
 ### Modifying step metadata at runtime
 In order to dynamically modify a step's metadata,
 the `StepService.setMetadata(step: Step, key: String, value: Any?)` function can be used.

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.2.0-SNAPSHOT-3"
+    version = projVersion ?: "0.2.0-SNAPSHOT-4"
 
     repositories {
         mavenCentral()

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/event/FlowEvent.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/event/FlowEvent.kt
@@ -8,4 +8,10 @@ import de.lise.fluxflow.api.workflow.Workflow
  */
 interface FlowEvent {
     val workflow: Workflow<*>
+
+    /**
+     * Contains context information associated with the current execution.
+     * May return `null`, if no context information has been provided.
+     */
+    val context: Any?
 }

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/StepDataService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/StepDataService.kt
@@ -6,4 +6,13 @@ interface StepDataService {
     fun getData(step: Step): List<Data<*>>
     fun <T> getData(step: Step, kind: DataKind): Data<T>?
     fun <T> setValue(data: Data<T>, value: T)
+
+    /**
+     * Assigns the given [value] to the [data] while also providing extra [context] information.
+     *
+     * @param context Arbitrary information to be passed along.
+     * @param value The value to be assigned.
+     * @param data The data to be updated.
+     */
+    fun <T> setValue(context: Any, data: Data<T>, value: T)
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/action/ActionEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/action/ActionEvent.kt
@@ -7,5 +7,7 @@ import de.lise.fluxflow.api.workflow.Workflow
 data class ActionEvent(val action: Action) : FlowEvent {
     override val workflow: Workflow<*>
         get() = action.step.workflow
+    override val context: Any?
+        get() = null
 }
 

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/StepCreatedEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/StepCreatedEvent.kt
@@ -6,4 +6,6 @@ import de.lise.fluxflow.api.workflow.Workflow
 class StepCreatedEvent(step: Step) : StepEvent(step) {
     override val workflow: Workflow<*>
         get() = step.workflow
+    override val context: Any?
+        get() = null
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/StepUpdatedEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/StepUpdatedEvent.kt
@@ -7,4 +7,6 @@ import de.lise.fluxflow.api.workflow.Workflow
 data class StepUpdatedEvent(val step: Step) : FlowEvent {
     override val workflow: Workflow<*>
         get() = step.workflow
+    override val context: Any?
+        get() = null
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/data/StepDataEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/step/data/StepDataEvent.kt
@@ -8,6 +8,7 @@ data class StepDataEvent(
     val stepData: Data<*>,
     val oldValue: Any?,
     val newValue: Any?,
+    override val context: Any?,
 ) : FlowEvent {
     override val workflow: Workflow<*>
         get() = stepData.step.workflow

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/BeforeWorkflowUpdateEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/BeforeWorkflowUpdateEvent.kt
@@ -12,4 +12,7 @@ import de.lise.fluxflow.api.workflow.Workflow
  * that the persist operation can be skipped because the workflow didn't really change.
  */
 @Deprecated("This event will not be raised in future versions of FluxFlow and is going to be removed.")
-class BeforeWorkflowUpdateEvent(workflow: Workflow<*>): WorkflowEvent(workflow)
+class BeforeWorkflowUpdateEvent(workflow: Workflow<*>): WorkflowEvent(workflow) {
+    override val context: Any?
+        get() = null
+}

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowCreatedEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowCreatedEvent.kt
@@ -2,4 +2,7 @@ package de.lise.fluxflow.engine.event.workflow
 
 import de.lise.fluxflow.api.workflow.Workflow
 
-class WorkflowCreatedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow)
+class WorkflowCreatedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow) {
+    override val context: Any?
+        get() = null
+}

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowDeletedEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowDeletedEvent.kt
@@ -1,4 +1,8 @@
 package de.lise.fluxflow.engine.event.workflow
 
 import de.lise.fluxflow.api.workflow.Workflow
-class WorkflowDeletedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow)
+
+class WorkflowDeletedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow) {
+    override val context: Any?
+        get() = null
+}

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowUpdatedEvent.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/event/workflow/WorkflowUpdatedEvent.kt
@@ -2,4 +2,7 @@ package de.lise.fluxflow.engine.event.workflow
 
 import de.lise.fluxflow.api.workflow.Workflow
 
-class WorkflowUpdatedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow)
+class WorkflowUpdatedEvent(workflow: Workflow<*>) : WorkflowEvent(workflow) {
+    override val context: Any?
+        get() = null
+}

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/StepDataServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/StepDataServiceImpl.kt
@@ -35,6 +35,14 @@ class StepDataServiceImpl(
     }
 
     override fun <T> setValue(data: Data<T>, value: T) {
+        doSetValue(null, data, value)
+    }
+
+    override fun <T> setValue(context: Any, data: Data<T>, value: T) {
+        doSetValue(context, data, value)
+    }
+
+    private fun <T> doSetValue(context: Any?, data: Data<T>, value: T) {
         if (modificationRequiresActiveStep(data)) {
             when (data.step.status) {
                 Status.Canceled -> throw InvalidStepStateException("Unable to invoke action on canceled step '${data.step.identifier}'")
@@ -70,7 +78,7 @@ class StepDataServiceImpl(
             the workflow should be in a clean state (= all changes should be persisted).
             Listeners should not expect that their changes will be persisted implicitly.
          */
-        eventService.publish(StepDataEvent(data, oldValue, value))
+        eventService.publish(StepDataEvent(data, oldValue, value, context))
     }
 
     private fun modificationRequiresActiveStep(data: Data<*>): Boolean {


### PR DESCRIPTION
The `StepDataService` now accepts an additional parameter allowing developers to pass additional context information.

Resolves #196 