### PR TITLE
Group jackson updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       day: "sunday"
       time: "11:00"
       timezone: "Europe/Berlin"
+    groups:
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson.*"


### PR DESCRIPTION
These changes will group future jackson updates into one pull request, since they seem to be updated together anyway:

![image](https://github.com/lisegmbh/fluxflow/assets/4678283/77b9952b-a930-4885-893c-3e41d46c4694)
