### PR TITLE
Use JUnit BOM for dependency version management and update to 5.12.0

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -59,8 +59,9 @@ subprojects {
         testImplementation("org.assertj:assertj-core:3.27.3")
         testImplementation("org.mockito:mockito-inline:5.2.0")
 
-        testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
-        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.4")
+        testImplementation(platform("org.junit:junit-bom:5.12.0"))
+        testImplementation("org.junit.jupiter:junit-jupiter")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 
     tasks.withType<Test> {

--- a/library/core/engine/build.gradle.kts
+++ b/library/core/engine/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(project(":springboot:springboot-testing"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.12.0")
+    testImplementation("org.junit.jupiter:junit-jupiter")
 }


### PR DESCRIPTION
* Added `platform("org.junit:junit-bom:5.12.0")` to manage JUnit dependencies centrally.
* Removed explicit versioning for `junit-jupiter` and `junit-platform-launcher`, relying on the BOM (= Bill of Materials).
* Ensured consistent and conflict-free dependency resolution for JUnit.

This improves maintainability and prevents version mismatches in test dependencies.