### PR TITLE
fix: prevent StackOverflowError caused by infinite ImMemoryAndFilter constructor chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    The `NullPointerException` that has been thrown within
    `ParamMatcher.isAssignable` when passing in a generic type has been fixed.
    [Issue #158](https://github.com/lisegmbh/fluxflow/issues/158)
+2. **SOE with AndFilter in InMemoryFilter**<br/>
+   Fixed a bug in the `InMemoryFilter` implementation where the `and` filter was not implemented correctly and caused a stack overflow error with infinite recursion of `and` calls.
+
 ### Removed
 1. Removed the unused `Type.toKClass()` extension function from `de.lise.fluxflow.reflection`.
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
     
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.2.0-SNAPSHOT-15"
+    version = projVersion ?: "0.2.0-SNAPSHOT-16"
 
     repositories {
         mavenCentral()

--- a/library/core/query/src/main/kotlin/de.lise.fluxflow.query/inmemory/filter/InMemoryAndFilter.kt
+++ b/library/core/query/src/main/kotlin/de.lise.fluxflow.query/inmemory/filter/InMemoryAndFilter.kt
@@ -5,8 +5,8 @@ import de.lise.fluxflow.query.filter.AndFilter
 data class InMemoryAndFilter<TModel>(
     private val filters: List<InMemoryFilter<TModel>>
 ) : InMemoryFilter<TModel> {
-    constructor(andFilter: AndFilter<TModel>) : this(andFilter.filters.map {
-        InMemoryFilter.fromDomainFilter(andFilter)
+    constructor(andFilter: AndFilter<TModel>) : this(andFilter.filters.map { filter ->
+        InMemoryFilter.fromDomainFilter(filter)
     })
 
     override fun toPredicate(): InMemoryPredicate<TModel> {

--- a/library/core/query/src/test/kotlin/de/lise/fluxflow/query/filter/InMemoryAndFilterTest.kt
+++ b/library/core/query/src/test/kotlin/de/lise/fluxflow/query/filter/InMemoryAndFilterTest.kt
@@ -1,0 +1,41 @@
+package de.lise.fluxflow.query.filter
+
+import de.lise.fluxflow.query.inmemory.filter.InMemoryAndFilter
+import de.lise.fluxflow.query.inmemory.filter.InMemoryContainsFilter
+import org.junit.jupiter.api.Test
+
+class InMemoryAndFilterTest {
+    @Test
+    fun `from AndFilter constructor should combine inner filters`() {
+        // Arrange
+        val innerFilter = ContainsFilter("ExpectedValue", false)
+        val innerFilter2 = ContainsFilter("AnotherExpectedValue", false)
+        val andFilter = InMemoryAndFilter(
+            AndFilter(
+                listOf(innerFilter, innerFilter2)
+            )
+        )
+
+        // Act
+        val result = andFilter.toPredicate()
+
+        // Assert
+        assert(result.test("ExpectedValue and AnotherExpectedValue"))
+    }
+
+    @Test
+    fun `from list constructor should combine inner filters`() {
+        // Arrange
+        val innerFilter = InMemoryContainsFilter("ExpectedValue")
+        val innerFilter2 = InMemoryContainsFilter("AnotherExpectedValue")
+        val andFilter = InMemoryAndFilter(
+            listOf(innerFilter, innerFilter2)
+        )
+
+        // Act
+        val result = andFilter.toPredicate()
+
+        // Assert
+        assert(result.test("ExpectedValue and AnotherExpectedValue"))
+    }
+}


### PR DESCRIPTION
Previously, using the AndFilter constructor lead to infinite nesting when an AndFilter was passed to another AndFilter constructor, causing a StackOverflowError.