### PR TITLE
Return continuations after action execution

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
 
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.2.0-SNAPSHOT-19"
+    version = projVersion ?: "0.2.0-SNAPSHOT-20"
 
     repositories {
         mavenCentral()

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/job/JobNotFoundException.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/job/JobNotFoundException.kt
@@ -1,0 +1,10 @@
+package de.lise.fluxflow.api.job
+
+import de.lise.fluxflow.api.workflow.Workflow
+
+class JobNotFoundException(
+    val workflow: Workflow<*>,
+    val identifier: JobIdentifier
+) : Exception(
+    "The job with id '$identifier' could not be found for workflow with id '${workflow.identifier}'"
+)

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/job/JobService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/job/JobService.kt
@@ -5,11 +5,24 @@ import de.lise.fluxflow.api.job.query.JobQuery
 import de.lise.fluxflow.api.workflow.Workflow
 import de.lise.fluxflow.query.pagination.Page
 
+/**
+ * Service interface for interacting with jobs in FluxFlow.
+ *
+ * Jobs represent asynchronous units of work that are scheduled to run at a specific time.
+ * This service provides operations to schedule, reschedule, cancel, duplicate, retrieve,
+ * and delete jobs associated with a workflow.
+ */
 interface JobService {
     /**
-     * Schedules the given job continuation.
-     * @param workflow The owning workflow for which the job should be scheduled.
-     * @param jobContinuation The [JobContinuation] to be scheduled.
+     * Schedules a new job for the given [workflow] using the provided [jobContinuation].
+     *
+     * The job will be persisted and executed at the time specified by the continuation.
+     * If a cancellation key is provided within the continuation and another job with the same key already exists,
+     * it will be replaced.
+     *
+     * @param workflow The workflow that owns the scheduled job.
+     * @param jobContinuation The job continuation to be scheduled.
+     * @return The resulting scheduled [Job] instance.
      */
     fun <TWorkflowModel, TJobModel> schedule(
         workflow: Workflow<TWorkflowModel>,
@@ -17,30 +30,102 @@ interface JobService {
     ) : Job
 
     /**
-     * Duplicates a given job and schedules it for the given workflow.
-     * @param workflow The owning workflow for which the job should be scheduled.
-     * @param job The [Job] from which the data should be used for scheduling.
+     * Duplicates a given [job] and reschedules it for the provided [workflow].
+     *
+     * This is useful when jobs need to be retried or manually repeated.
+     *
+     * @param workflow The workflow in which to reschedule the duplicated job.
+     * @param job The job instance to be duplicated and rescheduled.
+     * @return The newly scheduled duplicate job.
      */
     fun <TWorkflowModel> duplicateJob(
         workflow: Workflow<TWorkflowModel>,
         job: Job
     ) : Job
 
+    /**
+     * Cancels all jobs associated with the given [workflow] and [cancellationKey].
+     *
+     * Jobs can only be canceled if they are still in the `Scheduled` state.
+     *
+     * @param workflow The workflow whose jobs should be canceled.
+     * @param cancellationKey The key identifying which jobs to cancel.
+     */
     fun <TWorkflowModel> cancelAll(
         workflow: Workflow<TWorkflowModel>,
         cancellationKey: CancellationKey
     )
 
+    /**
+     * Deprecated: Use [getJob] or [getJobOrNull] instead.
+     *
+     * @see getJobOrNull
+     */
+    @Deprecated(
+        "In order to align the API naming, this function will be replace by .getJob() or .getJobOrNull()",
+            replaceWith = ReplaceWith("getJobOrNull<TWorkflowModel>(workflow, jobIdentifier)")
+    )
     fun <TWorkflowModel> findJob(
         workflow: Workflow<TWorkflowModel>,
         jobIdentifier: JobIdentifier
     ): Job?
 
+    /**
+     * Retrieves the job with the given [jobIdentifier] for the specified [workflow].
+     *
+     * Throws an exception if the job does not exist.
+     *
+     * @param workflow The workflow that owns the job.
+     * @param jobIdentifier The identifier of the job to retrieve.
+     * @return The [Job] instance.
+     */
+    fun <TWorkflowModel> getJob(
+        workflow: Workflow<TWorkflowModel>,
+        jobIdentifier: JobIdentifier
+    ): Job
+
+    /**
+     * Retrieves the job with the given [jobIdentifier] for the specified [workflow], or `null` if it does not exist.
+     *
+     * @param workflow The workflow that owns the job.
+     * @param jobIdentifier The identifier of the job to retrieve.
+     * @return The [Job] instance, or `null` if not found.
+     */
+    fun <TWorkflowModel> getJobOrNull(
+        workflow: Workflow<TWorkflowModel>,
+        jobIdentifier: JobIdentifier
+    ): Job?
+
+    /**
+     * Returns all jobs currently associated with the given [workflow].
+     *
+     * This includes scheduled, completed, and possibly failed jobs depending on the engine configuration.
+     *
+     * @param workflow The workflow whose jobs should be returned.
+     * @return A list of [Job] instances.
+     */
     fun <TWorkflowModel> findAllJobs(
         workflow: Workflow<TWorkflowModel>
     ): List<Job>
 
+    /**
+     * Returns a paginated list of jobs that match the given [query].
+     *
+     * This allows for filtering jobs globally (e.g., across all workflows) based on criteria
+     * such as status, job type, or creation time.
+     *
+     * @param query The query object defining search criteria.
+     * @return A [Page] containing matching [Job] instances.
+     */
     fun findAll(query: JobQuery): Page<Job>
 
+    /**
+     * Deletes all jobs matching the given [jobsIdentifiers].
+     *
+     * This operation should be used with caution, especially in production environments,
+     * as it may interfere with workflow execution or state consistency.
+     *
+     * @param jobsIdentifiers The identifiers of the jobs to delete.
+     */
     fun deleteAll(jobsIdentifiers: Set<JobIdentifier>)
 }

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionNotFoundException.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionNotFoundException.kt
@@ -1,0 +1,14 @@
+package de.lise.fluxflow.api.step.stateful.action
+
+import de.lise.fluxflow.api.step.Step
+
+class ActionNotFoundException(
+    val step: Step,
+    val kind: ActionKind
+): Exception(
+    "Step action of kind '$kind' could not be found for step (id: '${
+        step.identifier
+    }', kind: '${
+        step.definition.kind
+    }')"
+)

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionService.kt
@@ -1,5 +1,6 @@
 package de.lise.fluxflow.api.step.stateful.action
 
+import de.lise.fluxflow.api.continuation.Continuation
 import de.lise.fluxflow.api.step.Step
 
 /**
@@ -46,26 +47,30 @@ interface ActionService {
     fun getActionOrNull(step: Step, kind: ActionKind): Action?
 
     /**
-     * Invokes the given [action].
+     * Invokes the given [action] and returns the resulting [Continuation].
      *
-     * The implementation is responsible for providing any necessary parameter injection,
-     * continuation handling, and lifecycle management.
+     * **Note:** The continuation has already been processed and applied by the engine.
+     * You may use the returned value to inspect the outcome of the action.
      *
-     * @param action The action to invoke.
+     * @param action The action to execute.
+     * @return The [Continuation] that was produced and already executed.
      */
-    fun invokeAction(action: Action)
+    fun invokeAction(action: Action): Continuation<*>
 
     /**
-     * Convenience method to invoke the action of the specified [kind] on the given [step].
+     * Resolves and invokes the action of the given [kind] on the specified [step].
      *
-     * Internally retrieves the corresponding [Action] and then invokes it.
+     * Internally uses [getAction] followed by [invokeAction].
      *
-     * @param step The step containing the action.
-     * @param kind The kind identifier of the action.
-     * @throws ActionNotFoundException if there is no action for the given [step] and [kind].
+     * **Note:** The returned [Continuation] has already been executed by the engine.
+     *
+     * @param step The step that contains the action.
+     * @param kind The identifier of the action to invoke.
+     * @return The [Continuation] that was produced and already executed.
+     * @throws ActionNotFoundException if the action cannot be found.
      */
-    fun invokeAction(step: Step, kind: ActionKind) {
-        invokeAction(
+    fun invokeAction(step: Step, kind: ActionKind): Continuation<*> {
+        return invokeAction(
             getAction(
                 step,
                 kind

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/action/ActionService.kt
@@ -2,8 +2,74 @@ package de.lise.fluxflow.api.step.stateful.action
 
 import de.lise.fluxflow.api.step.Step
 
+/**
+ * Service interface for retrieving and invoking workflow actions associated with a step.
+ *
+ * An *action* represents a unit of executable behavior tied to a step in a workflow.
+ * Actions may originate from various sources — such as annotated Kotlin functions, external configuration
+ * files (e.g., XML), or other mechanisms — depending on the workflow engine’s implementation.
+ *
+ * This interface abstracts away the underlying definition mechanism and provides a unified API for working
+ * with actions at runtime.
+ */
 interface ActionService {
+    /**
+     * Returns all executable actions associated with the given [step].
+     *
+     * The origin and discovery mechanism of the actions (e.g., annotations, configuration, metadata)
+     * is not specified by this API and may vary depending on the implementation.
+     *
+     * @param step The step whose actions should be retrieved.
+     * @return A list of [Action] objects representing executable behavior.
+     */
     fun getActions(step: Step): List<Action>
-    fun getAction(step: Step, kind: ActionKind): Action?
+
+    /**
+     * Retrieves the action of the given [kind] associated with the provided [step].
+     *
+     * Throws an exception if no such action exists.
+     *
+     * @param step The step containing the action.
+     * @param kind The kind identifier of the action.
+     * @return The matching [Action].
+     * @throws ActionNotFoundException if there is no action for the given [step] and [kind].
+     */
+    fun getAction(step: Step, kind: ActionKind): Action
+
+    /**
+     * Retrieves the action of the given [kind] associated with the provided [step], or returns `null` if not found.
+     *
+     * @param step The step containing the action.
+     * @param kind The kind identifier of the action.
+     * @return The matching [Action], or `null` if not available.
+     */
+    fun getActionOrNull(step: Step, kind: ActionKind): Action?
+
+    /**
+     * Invokes the given [action].
+     *
+     * The implementation is responsible for providing any necessary parameter injection,
+     * continuation handling, and lifecycle management.
+     *
+     * @param action The action to invoke.
+     */
     fun invokeAction(action: Action)
+
+    /**
+     * Convenience method to invoke the action of the specified [kind] on the given [step].
+     *
+     * Internally retrieves the corresponding [Action] and then invokes it.
+     *
+     * @param step The step containing the action.
+     * @param kind The kind identifier of the action.
+     * @throws ActionNotFoundException if there is no action for the given [step] and [kind].
+     */
+    fun invokeAction(step: Step, kind: ActionKind) {
+        invokeAction(
+            getAction(
+                step,
+                kind
+            )
+        )
+    }
 }

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataNotFoundException.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataNotFoundException.kt
@@ -1,0 +1,14 @@
+package de.lise.fluxflow.api.step.stateful.data
+
+import de.lise.fluxflow.api.step.Step
+
+data class DataNotFoundException(
+    val step: Step,
+    val kind: DataKind
+) : Exception(
+    "Step data of kind '$kind' could not be found for step (id: '${
+        step.identifier
+    }', kind: '${
+        step.definition.kind
+    }')"
+)

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/StepDataService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/StepDataService.kt
@@ -1,16 +1,65 @@
 package de.lise.fluxflow.api.step.stateful.data
 
+import de.lise.fluxflow.api.event.FlowEvent
 import de.lise.fluxflow.api.step.Step
 
+/**
+ * Service interface for accessing and modifying step data associated with a [Step] during workflow execution.
+ *
+ * A step data entry represents a piece of mutable or immutable state tied to a step instance.
+ * Data entries may originate from public properties, annotated fields, or other metadata definitions,
+ * depending on the step implementation.
+ *
+ * This interface provides a technology-neutral way to discover and manipulate such data entries at runtime.
+ */
 interface StepDataService {
+    /**
+     * Retrieves all data entries defined for the given [step].
+     *
+     * Each returned [Data] instance represents a named field (also known as the data's kind)
+     * that holds part of the step's current state.
+     *
+     * @param step The step for which to retrieve data entries.
+     * @return A list of [Data] objects representing the step’s data.
+     */
     fun getData(step: Step): List<Data<*>>
-    fun <T> getData(step: Step, kind: DataKind): Data<T>?
+
+    /**
+     * Retrieves the data entry of the given [kind] from the specified [step].
+     *
+     * Throws an exception if the data kind does not exist.
+     *
+     * @param step The step containing the data.
+     * @param kind The identifier (kind) of the data entry.
+     * @return The corresponding [Data] object.
+     * @throws DataNotFoundException if there is no step data for the provided [step] and [kind].
+     */
+    fun <T> getData(step: Step, kind: DataKind): Data<T>
+
+    /**
+     * Retrieves the data entry of the given [kind] from the specified [step], or returns `null` if not found.
+     *
+     * @param step The step containing the data.
+     * @param kind The identifier (kind) of the data entry.
+     * @return The corresponding [Data] object, or `null` if unavailable.
+     */
+    fun <T> getDataOrNull(step: Step, kind: DataKind): Data<T>?
+
+    /**
+     * Sets the value of the given [data] entry.
+     *
+     * The update is performed without additional context information.
+     *
+     * @param data The data entry to update.
+     * @param value The new value to assign.
+     */
     fun <T> setValue(data: Data<T>, value: T)
 
     /**
      * Assigns the given [value] to the [data] while also providing extra [context] information.
      *
      * @param context Arbitrary information to be passed along.
+     * The provided value will (for example) be available on the emitted event (via [FlowEvent.context]).
      * @param value The value to be assigned.
      * @param data The data to be updated.
      */

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/WorkflowQueryService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/WorkflowQueryService.kt
@@ -59,6 +59,15 @@ interface WorkflowQueryService {
      * @param identifier the identifier of the workflow to be returned
      * @param TWorkflowModel the type of the workflow's model
      * @return the workflow with the given identifier
+     * @throws WorkflowNotFoundException if there is no workflow with the given [identifier].
      */
     fun <TWorkflowModel> get(identifier: WorkflowIdentifier): Workflow<TWorkflowModel>
+
+    /**
+     * Returns the workflow with the given identifier.
+     * @param identifier the identifier of the workflow to be returned
+     * @param TWorkflowModel the type of the workflow's model
+     * @return the workflow with the given identifier, or `null` if there is no workflow with the given [identifier].
+     */
+    fun <TWorkflowModel> getOrNull(identifier: WorkflowIdentifier): Workflow<TWorkflowModel>?
 }

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionNotFoundException.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionNotFoundException.kt
@@ -7,7 +7,7 @@ class WorkflowActionNotFoundException(
     val workflow: Workflow<*>,
     val kind: ActionKind
 ): Exception(
-    "Action of kind '${kind}' could not be found for workflow ${
+    "Workflow action of kind '$kind' could not be found for workflow ${
         workflow.identifier
     } (available kinds: ${
         workflow.definition.actions

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionService.kt
@@ -22,10 +22,20 @@ interface WorkflowActionService {
      * @param TModel The workflow model's type.
      * @param workflow The workflow from which the action should be obtained.
      * @param kind The expected [de.lise.fluxflow.api.step.stateful.action.ActionKind].
-     * @return The [WorkflowAction], or `null` if no action with the given [kind] is available.
+     * @return The [WorkflowAction] with the given [kind].
      * @throws WorkflowActionNotFoundException if there is no action of the specified [kind].
      */
     fun <TModel : Any> getAction(workflow: Workflow<TModel>, kind: ActionKind): WorkflowAction<TModel>
+
+    /**
+     * Returns a workflow action of the given [kind] or `null`, if no such action exists.
+     *
+     * @param TModel The workflow model's type.
+     * @param workflow The workflow from which the action should be obtained.
+     * @param kind The expected [de.lise.fluxflow.api.step.stateful.action.ActionKind].
+     * @return The [WorkflowAction], or `null` if no action with the given [kind] is available.
+     */
+    fun <TModel : Any> getActionOrNull(workflow: Workflow<TModel>, kind: ActionKind): WorkflowAction<TModel>?
 
     /**
      * Executes the given [action] while handling all required side effects.

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionService.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/workflow/action/WorkflowActionService.kt
@@ -1,5 +1,6 @@
 package de.lise.fluxflow.api.workflow.action
 
+import de.lise.fluxflow.api.continuation.Continuation
 import de.lise.fluxflow.api.step.stateful.action.ActionKind
 import de.lise.fluxflow.api.workflow.Workflow
 
@@ -38,25 +39,31 @@ interface WorkflowActionService {
     fun <TModel : Any> getActionOrNull(workflow: Workflow<TModel>, kind: ActionKind): WorkflowAction<TModel>?
 
     /**
-     * Executes the given [action] while handling all required side effects.
+     * Invokes the given workflow [action] and returns the resulting [Continuation].
      *
-     * @param action The action to be executed.
+     * **Note:** The continuation has already been fully executed by the workflow engine.
+     * It is returned only for inspection or post-processing purposes.
+     * Consumers must not use it to manipulate the workflow state manually.
+     *
+     * @param action The workflow action to invoke.
+     * @return The [Continuation] that was produced and already executed.
      */
-    fun <TModel : Any> invokeAction(action: WorkflowAction<TModel>)
+    fun <TModel : Any> invokeAction(action: WorkflowAction<TModel>): Continuation<*>
 
     /**
-     * Execute a workflow action based on its [kind].
+     * Resolves and invokes the workflow action of the given [kind] on the specified [workflow].
      *
-     * **Note** that this is a convenience overload.
-     * One could also fetch the action first (using [getAction])
-     * and then execute it using the other [invokeAction] overload.
+     * Internally delegates to [getAction] and [invokeAction].
+     *
+     * **Note:** The returned [Continuation] has already been executed.
      *
      * @param TModel The workflow model's type.
-     * @param workflow The workflow from which the action should be obtained.
-     * @param kind The kind of the action to be executed.
+     * @param workflow The workflow on which the action should be executed.
+     * @param kind The kind identifier of the action to invoke.
+     * @return The [Continuation] that was produced and already executed.
      */
-    fun <TModel : Any> invokeAction(workflow: Workflow<TModel>, kind: ActionKind) {
-        invokeAction(
+    fun <TModel : Any> invokeAction(workflow: Workflow<TModel>, kind: ActionKind): Continuation<*> {
+        return invokeAction(
             getAction(
                 workflow,
                 kind

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/job/JobSchedulingCallback.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/job/JobSchedulingCallback.kt
@@ -41,7 +41,7 @@ class JobSchedulingCallback(
             return
         }
 
-        val job = ref.alreadyLoadedJob ?: jobService.findJob(workflow, ref.jobIdentifier)
+        val job = ref.alreadyLoadedJob ?: jobService.getJobOrNull(workflow, ref.jobIdentifier)
         if (job == null) {
             Logger.warn("Job definition for scheduled job \"{}\" seems to be lost.", ref)
             return
@@ -57,6 +57,7 @@ class JobSchedulingCallback(
             return
         }
         jobService.setStatus(runningJob, JobStatus.Executed)
+        @Suppress("UNCHECKED_CAST")
         workflowUpdateService.saveChanges(workflow as Workflow<Any>)
         continuationService.execute(
             workflow, 

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/job/JobServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/job/JobServiceImpl.kt
@@ -131,7 +131,26 @@ class JobServiceImpl(
         return jobActivationService.activate(job.workflow, updatedJobData)
     }
 
+    @Deprecated(
+        "In order to align the API naming, this function will be replace by .getJob() or .getJobOrNull()",
+        replaceWith = ReplaceWith("getJobOrNull<TWorkflowModel>(workflow, jobIdentifier)")
+    )
     override fun <TWorkflowModel> findJob(workflow: Workflow<TWorkflowModel>, jobIdentifier: JobIdentifier): Job? {
+        return getJobOrNull(workflow, jobIdentifier)
+    }
+
+    override fun <TWorkflowModel> getJob(
+        workflow: Workflow<TWorkflowModel>,
+        jobIdentifier: JobIdentifier
+    ): Job {
+        return getJobOrNull(workflow, jobIdentifier)
+            ?: throw JobNotFoundException(workflow, jobIdentifier)
+    }
+
+    override fun <TWorkflowModel> getJobOrNull(
+        workflow: Workflow<TWorkflowModel>,
+        jobIdentifier: JobIdentifier
+    ): Job? {
         return jobPersistence.findForWorkflowAndId(workflow.identifier, jobIdentifier)
             ?.let { jobActivationService.activate(workflow, it) }
     }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/action/ActionServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/action/ActionServiceImpl.kt
@@ -1,6 +1,7 @@
 package de.lise.fluxflow.engine.step.action
 
 import de.lise.fluxflow.api.ReferredWorkflowObject
+import de.lise.fluxflow.api.continuation.Continuation
 import de.lise.fluxflow.api.event.EventService
 import de.lise.fluxflow.api.step.InvalidStepStateException
 import de.lise.fluxflow.api.step.Status
@@ -41,7 +42,7 @@ class ActionServiceImpl(
             )
     }
 
-    override fun invokeAction(action: Action) {
+    override fun invokeAction(action: Action): Continuation<*> {
         validationService.validateBeforeAction(action)
         when (action.step.status) {
             Status.Canceled -> throw InvalidStepStateException("Unable to invoke action on canceled step '${action.step.identifier}'")
@@ -65,5 +66,7 @@ class ActionServiceImpl(
             ReferredWorkflowObject.Companion.create(action.step), 
             continuation,
         )
+
+        return continuation
     }
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/action/ActionServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/action/ActionServiceImpl.kt
@@ -8,6 +8,7 @@ import de.lise.fluxflow.api.step.Step
 import de.lise.fluxflow.api.step.stateful.StatefulStep
 import de.lise.fluxflow.api.step.stateful.action.Action
 import de.lise.fluxflow.api.step.stateful.action.ActionKind
+import de.lise.fluxflow.api.step.stateful.action.ActionNotFoundException
 import de.lise.fluxflow.api.step.stateful.action.ActionService
 import de.lise.fluxflow.api.workflow.Workflow
 import de.lise.fluxflow.api.workflow.WorkflowUpdateService
@@ -27,9 +28,17 @@ class ActionServiceImpl(
             ?: emptyList()
     }
 
-    override fun getAction(step: Step, kind: ActionKind): Action? {
+    override fun getActionOrNull(step: Step, kind: ActionKind): Action? {
         return getActions(step)
             .firstOrNull { it.definition.kind == kind }
+    }
+
+    override fun getAction(step: Step, kind: ActionKind): Action {
+        return getActionOrNull(step, kind)
+            ?: throw ActionNotFoundException(
+                step,
+                kind
+            )
     }
 
     override fun invokeAction(action: Action) {

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/StepDataServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/StepDataServiceImpl.kt
@@ -27,12 +27,17 @@ class StepDataServiceImpl(
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getData(step: Step, kind: DataKind): Data<T>? {
+    override fun <T> getDataOrNull(step: Step, kind: DataKind): Data<T>? {
         return getData(step).firstOrNull {
             it.definition.kind == kind
         }?.let {
             it as Data<T>
         }
+    }
+
+    override fun <T> getData(step: Step, kind: DataKind): Data<T> {
+        return getDataOrNull(step, kind)
+            ?: throw DataNotFoundException(step, kind)
     }
 
     override fun <T> setValue(data: Data<T>, value: T) {

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowQueryServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowQueryServiceImpl.kt
@@ -64,10 +64,15 @@ class WorkflowQueryServiceImpl(
         }
     }
 
-    override fun <TWorkflowModel> get(identifier: WorkflowIdentifier): Workflow<TWorkflowModel> {
+    override fun <TWorkflowModel> getOrNull(identifier: WorkflowIdentifier): Workflow<TWorkflowModel>? {
         return persistence.find(identifier)
             ?.let {
                 activationService.activate(it)
-            } ?: throw WorkflowNotFoundException(identifier)
+            }
+    }
+
+    override fun <TWorkflowModel> get(identifier: WorkflowIdentifier): Workflow<TWorkflowModel> {
+        return getOrNull(identifier)
+            ?: throw WorkflowNotFoundException(identifier)
     }
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/WorkflowServiceImpl.kt
@@ -50,6 +50,10 @@ class WorkflowServiceImpl(
         return workflowQueryService.get(identifier)
     }
 
+    override fun <TWorkflowModel> getOrNull(identifier: WorkflowIdentifier): Workflow<TWorkflowModel>? {
+        return workflowQueryService.getOrNull(identifier)
+    }
+
     override fun <TWorkflowModel> saveChanges(workflow: Workflow<TWorkflowModel>): Workflow<TWorkflowModel> {
         return workflowUpdateService.saveChanges(workflow)
     }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/action/WorkflowActionServiceImpl.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/workflow/action/WorkflowActionServiceImpl.kt
@@ -1,5 +1,6 @@
 package de.lise.fluxflow.engine.workflow.action
 
+import de.lise.fluxflow.api.continuation.Continuation
 import de.lise.fluxflow.api.event.EventService
 import de.lise.fluxflow.api.step.stateful.action.ActionKind
 import de.lise.fluxflow.api.workflow.Workflow
@@ -39,7 +40,7 @@ class WorkflowActionServiceImpl(
         }
     }
 
-    override fun <TModel : Any> invokeAction(action: WorkflowAction<TModel>) {
+    override fun <TModel : Any> invokeAction(action: WorkflowAction<TModel>): Continuation<*> {
         val continuation = action.execute()
 
         eventService.publish(WorkflowActionEvent(action))
@@ -53,5 +54,7 @@ class WorkflowActionServiceImpl(
             null,
             continuation
         )
+
+        return continuation
     }
 }

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/job/JobSchedulingCallbackTest.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/job/JobSchedulingCallbackTest.kt
@@ -37,7 +37,7 @@ class JobSchedulingCallbackTest {
             on { identifier } doReturn jobIdentifier
         }
         val jobService = mock<JobServiceImpl> {
-            on { findJob<Any>(any(), any()) } doReturn testJob
+            on { getJobOrNull<Any>(any(), any()) } doReturn testJob
             on { setStatus(any(), any()) } doReturn testJob
         }
         val continuationService = mock<ContinuationService> {}
@@ -81,7 +81,7 @@ class JobSchedulingCallbackTest {
             on { execute() }.doThrow(RuntimeException("surprise surprise"))
         }
         val jobService = mock<JobServiceImpl> {
-            on { findJob<Any>(any(), any()) }.doReturn(testJob)
+            on { getJobOrNull<Any>(any(), any()) }.doReturn(testJob)
             on { setStatus(any(), any()) }.doReturn(testJob)
         }
         val continuationService = mock<ContinuationService> {}
@@ -138,7 +138,7 @@ class JobSchedulingCallbackTest {
             .createJob(jobIdentifier, workflow, Instant.now(), null, JobStatus.Scheduled)
 
         val jobService = mock<JobServiceImpl> {
-            on { findJob<Any>(any(), any()) }.doReturn(modifyingTestJob)
+            on { getJobOrNull<Any>(any(), any()) }.doReturn(modifyingTestJob)
             on { setStatus(any(), any()) }.doReturn(modifyingTestJob)
         }
         val persistedWorkflowCaptor = argumentCaptor<Workflow<Any>> { }


### PR DESCRIPTION
This PR improves the interfaces of some workflow services (naming, null-handling). Functions that invoke actions do now return the resulting continuation. This resolves #323.