### PR TITLE
DataDefinition now exposes isReadonly

### DIFF
--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataDefinition.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataDefinition.kt
@@ -34,5 +34,12 @@ interface DataDefinition<T> {
      * Controls if inactive data can be modified.
      */
     val modificationPolicy: ModificationPolicy
+
+    /**
+     * Indicates if this definition describes a read-only (see [Data])
+     * or modifiable data element (see [ModifiableData]).
+     */
+    val isReadonly: Boolean
+
     fun createData(step: Step): Data<T>
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/RestoredDataDefinition.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/RestoredDataDefinition.kt
@@ -22,7 +22,8 @@ class RestoredDataDefinition(
         get() = emptyList()
     override val validation: DataValidationDefinition?
         get() = null
-
+    override val isReadonly: Boolean
+        get() = true
 
     constructor(
         dataDefinitionData: DataDefinitionData,

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
@@ -18,6 +18,9 @@ class ReflectedDataDefinition<TInstance, TModel>(
     private val propertyGetter: PropertyGetter<TInstance, TModel>,
     private val propertySetter: PropertySetter<TInstance, TModel>? = null,
 ) : DataDefinition<TModel> {
+    override val isReadonly: Boolean
+        get() = propertySetter == null
+
     override fun createData(step: Step): Data<TModel> {
         val readOnlyData = ReflectedData(
             step,

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
@@ -43,6 +43,7 @@ class DataDefinitionBuilderTest {
 
         // Assert
         assertThat(data).isNotInstanceOf(ModifiableData::class.java)
+        assertThat(data.definition.isReadonly).isTrue()
     }
 
     @Test
@@ -55,8 +56,8 @@ class DataDefinitionBuilderTest {
 
         // Assert
         assertThat(data).isInstanceOf(ModifiableData::class.java)
+        assertThat(data.definition.isReadonly).isFalse()
     }
-
 
     @Test
     fun `build should return a builder that creates a data definition accessing the correct property`() {


### PR DESCRIPTION
to indicate if the described data element will be immutable. This resolves #326.