### PR TITLE
Reconcile the scheduled jobs with scheduling implementation on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    Similar to steps, jobs, and step data, workflow definitions now support metadata. The metadata is automatically extracted from
    annotations present on the workflow model class. This metadata can be accessed via the `WorkflowDefinition.metadata` property.
    [Issue #86](https://github.com/lisegmbh/fluxflow/issues/86) and [Issue #50](https://github.com/lisegmbh/fluxflow/issues/50)
-   
+12. **Scheduled job reconciliation on startup**<br/>
+    Added a startup `BootstrapAction` that validates all jobs marked as `Scheduled` in persistence and automatically reschedules any that are missing from the active scheduler implementation. Enable with `fluxflow.scheduling.reconcile-on-startup=true`.
+
 ### Changed
 1. **Configurable replacement scope for workflow continuations**<br/>
    The `Continuation.workflow` function now supports a `replacementScope` parameter that defines which workflow elements should be replaced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    annotations present on the workflow model class. This metadata can be accessed via the `WorkflowDefinition.metadata` property.
    [Issue #86](https://github.com/lisegmbh/fluxflow/issues/86) and [Issue #50](https://github.com/lisegmbh/fluxflow/issues/50)
 12. **Scheduled job reconciliation on startup**<br/>
-    Added a startup `BootstrapAction` that validates all jobs marked as `Scheduled` in persistence and automatically reschedules any that are missing from the active scheduler implementation. Enable with `fluxflow.scheduling.reconcile-on-startup=true`.
+    Added a startup `BootstrapAction` that validates all jobs marked as `Scheduled` in persistence and automatically reschedules any that are missing from the active scheduler implementation. Enable with `fluxflow.scheduling.reconcileOnStartup=true`.
 
 ### Changed
 1. **Configurable replacement scope for workflow continuations**<br/>
@@ -48,7 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 2. Added an optional `version` property to MongoDB's StepDocument.
    There is no need for a migration, as the field is optional/nullable.
 3. A custom collation can now be specified when ensuring indexes using `MongoBootstrapAction`.
-4. MongoDB documents now use a different data structure to store map entries and their data types. See [https://docs.fluxflow.cloud/see/1](https://docs.fluxflow.cloud/see/1) for more information. 
+4. MongoDB documents now use a different data structure to store map entries and their data types. See [https://docs.fluxflow.cloud/see/1](https://docs.fluxflow.cloud/see/1) for more information.
+5. If a FluxFlow job has no explicit cancellation key,  
+   Quartz now uses the workflow and job identifier as the job key.  
+   This enables more efficient lookups for pre-scheduled jobs.  
+   To fall back to lookups based on the job detail map (which requires iterating over all scheduled jobs),  
+   set `fluxflow.quartz.legacyLookup` to `true`.
+
 ### Deprecated
 ### Fixed
 1. **NPE within ParamMatcher.isAssignable**<br/>

--- a/docs/spring/settings.md
+++ b/docs/spring/settings.md
@@ -72,6 +72,17 @@ fluxflow:
       # Same model as `fluxflow.mongo.collation.default`, 
       # which will be used if omitted.
       continuationRecord: null
+  
+  quartz:
+    # boolean: if set to true, Quartz will search for pre-scheduled jobs by also comparing their job data map.
+    # Note that enabling this might come with a performance impact, 
+    # as it may require iterating over all previously scheduled jobs [O(n^2)].
+    legacyLookup: false
+
+  scheduling:
+    # boolean: if true,
+    # FluxFlow will attempt to re-schedule jobs that are missing from the scheduler's persistent storage.
+    reconcileOnStartup: false
 
   versioning:
     comparison: # Can be used to tweak the compatibility when comparing different versions

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
 
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.2.0-SNAPSHOT-21"
+    version = projVersion ?: "0.2.0-SNAPSHOT-22"
 
     repositories {
         mavenCentral()

--- a/library/core/scheduling/src/main/kotlin/de/lise/fluxflow/scheduling/SchedulingService.kt
+++ b/library/core/scheduling/src/main/kotlin/de/lise/fluxflow/scheduling/SchedulingService.kt
@@ -27,4 +27,11 @@ interface SchedulingService {
     fun cancel(workflowIdentifier: WorkflowIdentifier, cancellationKey: CancellationKey)
 
     fun registerListener(callback: SchedulingCallback)
+
+    /**
+     * Checks if a job is scheduled.
+     * @param schedulingReference The reference of the job to check.
+     * @return `true` if the job is scheduled, `false` otherwise.
+     */
+    fun isJobScheduled(schedulingReference: SchedulingReference): Boolean
 }

--- a/library/core/test-scheduling/src/main/kotlin/de/lise/fluxflow/test/scheduling/TestSchedulingService.kt
+++ b/library/core/test-scheduling/src/main/kotlin/de/lise/fluxflow/test/scheduling/TestSchedulingService.kt
@@ -74,6 +74,17 @@ class TestSchedulingService(
         callbacks.add(callback)
     }
 
+    override fun isJobScheduled(schedulingReference: SchedulingReference): Boolean {
+        return schedulingReference.cancellationKey?.let {
+            concurrentCancellationMap.containsKey(
+                TestCancellationKey(
+                    schedulingReference.workflowIdentifier,
+                    it
+                )
+            )
+        } ?: false
+    }
+
     private fun notify(schedulingReference: SchedulingReference) {
         callbacks.forEach {
             try {

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/autoconfigure/QuartzSchedulingConfiguration.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/autoconfigure/QuartzSchedulingConfiguration.kt
@@ -3,6 +3,7 @@ package de.lise.fluxflow.springboot.autoconfigure
 import de.lise.fluxflow.scheduling.SchedulingService
 import de.lise.fluxflow.springboot.scheduling.quartz.QuartzSchedulingService
 import org.quartz.Scheduler
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Bean
@@ -18,11 +19,16 @@ open class QuartzSchedulingConfiguration {
     @ConditionalOnBean(Scheduler::class)
     open fun schedulingService(
         scheduler: Scheduler,
-        clock: Clock
+        clock: Clock,
+        @Value(
+            "\${fluxflow.quartz.legacyLookup:false}"
+        )
+        enableLegacyLookup: Boolean
     ): SchedulingService {
         return QuartzSchedulingService(
             scheduler,
-            clock
+            clock,
+            enableLegacyLookup
         )
     }
 }

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/JobDataMapKeys.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/JobDataMapKeys.kt
@@ -1,0 +1,6 @@
+package de.lise.fluxflow.springboot.scheduling.quartz
+
+object JobDataMapKeys {
+    const val JOB_IDENTIFIER = "jobIdentifier"
+    const val WORKFLOW_IDENTIFIER = "workflowIdentifier"
+}

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzScheduledJob.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzScheduledJob.kt
@@ -1,9 +1,9 @@
 package de.lise.fluxflow.springboot.scheduling.quartz
 
 import de.lise.fluxflow.api.job.CancellationKey
-import de.lise.fluxflow.api.job.JobIdentifier
-import de.lise.fluxflow.api.workflow.WorkflowIdentifier
 import de.lise.fluxflow.scheduling.SchedulingReference
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.jobIdentifier
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.workflowIdentifier
 import org.quartz.JobExecutionContext
 import org.springframework.scheduling.quartz.QuartzJobBean
 
@@ -11,12 +11,8 @@ class QuartzScheduledJob(
     private val quartzSchedulingService: QuartzSchedulingService
 ) : QuartzJobBean() {
     override fun executeInternal(context: JobExecutionContext) {
-        val jobIdentifier = JobIdentifier(
-            context.jobDetail!!.jobDataMap!!["jobIdentifier"]!! as String
-        )
-        val workflowIdentifier = WorkflowIdentifier(
-            context.jobDetail!!.jobDataMap!!["workflowIdentifier"]!! as String
-        )
+        val jobIdentifier = context.jobDetail?.jobIdentifier !!
+        val workflowIdentifier = context.jobDetail?.workflowIdentifier!!
         val cancellationKey = context.jobDetail!!.key?.name?.let {
             CancellationKey(
                 it

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzSchedulingService.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzSchedulingService.kt
@@ -5,61 +5,82 @@ import de.lise.fluxflow.api.workflow.WorkflowIdentifier
 import de.lise.fluxflow.scheduling.SchedulingCallback
 import de.lise.fluxflow.scheduling.SchedulingReference
 import de.lise.fluxflow.scheduling.SchedulingService
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.jobIdentifier
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.toJobData
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.toKey
+import de.lise.fluxflow.springboot.scheduling.quartz.ext.workflowIdentifier
 import org.quartz.*
 import org.quartz.impl.matchers.GroupMatcher
 import java.time.Clock
 import java.time.Instant
 import java.util.*
 
+/**
+ * Quartz-based implementation of [SchedulingService].
+ *
+ * This service uses Quartz to schedule and manage workloads.
+ *
+ * @param scheduler The fully initialized Quartz scheduler.
+ * @param clock The clock instance used to obtain the current time.
+ * @param enableLegacyLookup If `true`, enables the legacy lookup for scheduled jobs.
+ * In earlier implementations, a deterministic Quartz job key was not assigned
+ * when no cancellation key was provided.
+ * This caused inefficient lookups,
+ * as the service had to iterate over all scheduled jobs to find the matching job data.
+ */
 open class QuartzSchedulingService(
     private val scheduler: Scheduler,
-    private val clock: Clock
+    private val clock: Clock,
+    private val enableLegacyLookup: Boolean,
 ) : SchedulingService {
     private val listeners: MutableList<SchedulingCallback> = mutableListOf()
 
     protected open fun createJobMetadata(
         pointInTime: Instant,
-        schedulingReference: SchedulingReference
+        schedulingReference: SchedulingReference,
     ): JobDetail {
-        var builder = JobBuilder
+        return JobBuilder
             .newJob(QuartzScheduledJob::class.java)
-
-            .usingJobData(
-                "jobIdentifier", schedulingReference.jobIdentifier.value
-            ).usingJobData(
-                "workflowIdentifier", schedulingReference.workflowIdentifier.value
-            )
-
-        schedulingReference.cancellationKey?.let {
-            builder = builder.withIdentity(
-                it.value,
-                schedulingReference.workflowIdentifier.value
-            )
-        }
-
-        return builder.build()
+            .usingJobData(schedulingReference.toJobData())
+            .withIdentity(schedulingReference.toKey())
+            .build()
     }
 
     protected open fun createTrigger(
         pointInTime: Instant,
-        schedulingReference: SchedulingReference
+        schedulingReference: SchedulingReference,
     ): Trigger {
         return TriggerBuilder.newTrigger()
             .startAt(Date.from(pointInTime))
             .build()
     }
 
-    override fun schedule(pointInTime: Instant, schedulingReference: SchedulingReference) {
+    override fun schedule(
+        pointInTime: Instant,
+        schedulingReference: SchedulingReference,
+    ) {
         if (pointInTime <= clock.instant()) {
             return notify(schedulingReference)
         }
-        val job = createJobMetadata(pointInTime, schedulingReference)
-        val trigger = createTrigger(pointInTime, schedulingReference)
+        val job = createJobMetadata(
+            pointInTime,
+            schedulingReference
+        )
+        val trigger = createTrigger(
+            pointInTime,
+            schedulingReference
+        )
 
-        scheduler.scheduleJob(job, trigger)
+        scheduler.scheduleJob(
+            job,
+            trigger
+        )
     }
 
-    override fun cancel(workflowIdentifier: WorkflowIdentifier, cancellationKey: CancellationKey) {
+    override fun cancel(
+        workflowIdentifier: WorkflowIdentifier,
+        cancellationKey: CancellationKey,
+    ) {
         scheduler.deleteJob(
             JobKey.jobKey(
                 cancellationKey.value,
@@ -78,17 +99,34 @@ open class QuartzSchedulingService(
         }
     }
 
-    override fun isJobScheduled(
-        schedulingReference: SchedulingReference
-    ): Boolean {
-        return getScheduledJobKeys().any { jobKey ->
-            val job = scheduler.getJobDetail(jobKey) ?: return@any false
-            val jobId = job.jobDataMap["jobIdentifier"] as? String
-
-            jobId == schedulingReference.jobIdentifier.value
+    fun getJobDetail(
+        schedulingRef: SchedulingReference,
+    ): JobDetail? {
+        val detailsFromKey = scheduler.getJobDetail(
+            schedulingRef.toKey()
+        )
+        if (detailsFromKey != null || !enableLegacyLookup) {
+            return detailsFromKey
         }
+
+        // Otherwise, search for it by searching within the job data
+        for (existingKey in scheduler.getJobKeys(GroupMatcher.anyGroup())) {
+            val details = scheduler.getJobDetail(existingKey)
+            if (
+                details.jobIdentifier == schedulingRef.jobIdentifier &&
+                details.workflowIdentifier == schedulingRef.workflowIdentifier
+            ) {
+                return details
+            }
+        }
+
+        return null
     }
 
-    private fun getScheduledJobKeys(): Set<JobKey> = scheduler.getJobKeys(GroupMatcher.anyGroup()).toSet()
+    override fun isJobScheduled(
+        schedulingReference: SchedulingReference,
+    ): Boolean {
+        return getJobDetail(schedulingReference) != null
+    }
 }
 

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzSchedulingService.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/QuartzSchedulingService.kt
@@ -6,6 +6,7 @@ import de.lise.fluxflow.scheduling.SchedulingCallback
 import de.lise.fluxflow.scheduling.SchedulingReference
 import de.lise.fluxflow.scheduling.SchedulingService
 import org.quartz.*
+import org.quartz.impl.matchers.GroupMatcher
 import java.time.Clock
 import java.time.Instant
 import java.util.*
@@ -76,5 +77,18 @@ open class QuartzSchedulingService(
             listener.onScheduled(ref)
         }
     }
+
+    override fun isJobScheduled(
+        schedulingReference: SchedulingReference
+    ): Boolean {
+        return getScheduledJobKeys().any { jobKey ->
+            val job = scheduler.getJobDetail(jobKey) ?: return@any false
+            val jobId = job.jobDataMap["jobIdentifier"] as? String
+
+            jobId == schedulingReference.jobIdentifier.value
+        }
+    }
+
+    private fun getScheduledJobKeys(): Set<JobKey> = scheduler.getJobKeys(GroupMatcher.anyGroup()).toSet()
 }
 

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/ext/JobDetail.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/ext/JobDetail.kt
@@ -1,0 +1,24 @@
+package de.lise.fluxflow.springboot.scheduling.quartz.ext
+
+import de.lise.fluxflow.api.job.JobIdentifier
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.springboot.scheduling.quartz.JobDataMapKeys
+import org.quartz.JobDetail
+
+val JobDetail.jobIdentifier: JobIdentifier?
+    get() {
+        return this.jobDataMap[JobDataMapKeys.JOB_IDENTIFIER]?.let {
+            it as? String
+        }?.let {
+            JobIdentifier(it)
+        }
+    }
+
+val JobDetail.workflowIdentifier: WorkflowIdentifier?
+    get() {
+        return this.jobDataMap[JobDataMapKeys.WORKFLOW_IDENTIFIER]?.let { 
+            it as? String
+        }?.let {
+            WorkflowIdentifier(it)
+        }
+    }

--- a/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/ext/SchedulingReference.kt
+++ b/library/springboot/springboot-quartz/src/main/kotlin/de/lise/fluxflow/springboot/scheduling/quartz/ext/SchedulingReference.kt
@@ -1,0 +1,25 @@
+package de.lise.fluxflow.springboot.scheduling.quartz.ext
+
+import de.lise.fluxflow.scheduling.SchedulingReference
+import de.lise.fluxflow.springboot.scheduling.quartz.JobDataMapKeys
+import org.quartz.JobDataMap
+import org.quartz.JobKey
+
+fun SchedulingReference.toKey(): JobKey {
+    return this.cancellationKey?.let {
+        JobKey(
+            it.value,
+            this.workflowIdentifier.value
+        )
+    }?: JobKey(
+        this.jobIdentifier.value,
+        this.workflowIdentifier.value
+    )
+}
+
+fun SchedulingReference.toJobData(): JobDataMap {
+    return JobDataMap(mapOf(
+        JobDataMapKeys.JOB_IDENTIFIER to this.jobIdentifier.value,
+        JobDataMapKeys.WORKFLOW_IDENTIFIER to this.workflowIdentifier.value
+    ))
+}

--- a/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/bootstrapping/ReconcileScheduledJobsBootstrapAction.kt
+++ b/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/bootstrapping/ReconcileScheduledJobsBootstrapAction.kt
@@ -1,0 +1,70 @@
+package de.lise.fluxflow.springboot.bootstrapping
+
+import de.lise.fluxflow.api.bootstrapping.BootstrapAction
+import de.lise.fluxflow.api.job.Job
+import de.lise.fluxflow.api.job.JobService
+import de.lise.fluxflow.api.job.JobStatus
+import de.lise.fluxflow.api.job.query.filter.JobFilter
+import de.lise.fluxflow.query.Query
+import de.lise.fluxflow.query.filter.Filter
+import de.lise.fluxflow.scheduling.SchedulingReference
+import de.lise.fluxflow.scheduling.SchedulingService
+import org.slf4j.LoggerFactory
+
+class ReconcileScheduledJobsBootstrapAction(
+    private val jobService: JobService,
+    private val schedulingService: SchedulingService,
+) : BootstrapAction {
+    override fun setup() {
+        Logger.info("Reconciling scheduled jobs on startup...")
+
+        val scheduledJobs = jobService.findAll(
+            Query.withFilter(
+                JobFilter.empty().withStatus(
+                    Filter.eq(JobStatus.Scheduled)
+                )
+            )
+        )
+
+        if (scheduledJobs.items.isEmpty()) {
+            Logger.info("No scheduled jobs found on startup.")
+            return
+        }
+
+        scheduledJobs.items.forEach { job ->
+            scheduleJobIfNeeded(job)
+        }
+
+        Logger.info("Scheduled job reconciliation completed.")
+    }
+
+    private fun scheduleJobIfNeeded(job: Job) {
+        val schedulingReference = SchedulingReference(
+            job.workflow.identifier,
+            job.identifier,
+            job.cancellationKey,
+            null,
+        )
+        val isScheduled = schedulingService.isJobScheduled(
+            schedulingReference
+        )
+
+        if (isScheduled) {
+            return
+        }
+
+        Logger.warn(
+            "Job with identifier \"{}\" is marked Scheduled but not found in scheduler. Rescheduling it.",
+            job.identifier
+        )
+
+        schedulingService.schedule(
+            job.scheduledTime,
+            schedulingReference,
+        )
+    }
+
+    companion object {
+        private val Logger = LoggerFactory.getLogger(ReconcileScheduledJobsBootstrapAction::class.java)
+    }
+}

--- a/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
+++ b/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
@@ -696,7 +696,7 @@ open class BasicConfiguration {
     @Bean
     @Order(105)
     @ConditionalOnProperty(
-        value = ["fluxflow.scheduling.reconcile-on-startup"],
+        value = ["fluxflow.scheduling.reconcileOnStartup"],
         havingValue = "true",
         matchIfMissing = false
     )

--- a/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
+++ b/library/springboot/springboot/src/main/kotlin/de/lise/fluxflow/springboot/configuration/BasicConfiguration.kt
@@ -47,6 +47,7 @@ import de.lise.fluxflow.scheduling.SchedulingCallback
 import de.lise.fluxflow.scheduling.SchedulingService
 import de.lise.fluxflow.springboot.activation.StepKindMapBuilder
 import de.lise.fluxflow.springboot.activation.parameter.SpringValueExpressionParameterResolver
+import de.lise.fluxflow.springboot.bootstrapping.ReconcileScheduledJobsBootstrapAction
 import de.lise.fluxflow.springboot.bootstrapping.SpringBootstrapper
 import de.lise.fluxflow.springboot.expression.SpringSelectorExpressionParser
 import de.lise.fluxflow.springboot.ioc.SpringIocProvider
@@ -79,6 +80,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.*
+import org.springframework.core.annotation.Order
 import org.springframework.expression.spel.standard.SpelExpressionParser
 import java.time.Clock
 
@@ -691,4 +693,20 @@ open class BasicConfiguration {
         )
     }
 
+    @Bean
+    @Order(105)
+    @ConditionalOnProperty(
+        value = ["fluxflow.scheduling.reconcile-on-startup"],
+        havingValue = "true",
+        matchIfMissing = false
+    )
+    open fun startupJobReconciliation(
+        jobService: JobService,
+        schedulingService: SchedulingService,
+    ): BootstrapAction {
+        return ReconcileScheduledJobsBootstrapAction(
+            jobService,
+            schedulingService
+        )
+    }
 }


### PR DESCRIPTION
This PR adds an optional startup reconciliation that ensures jobs marked as Scheduled in persistence are present in the active scheduler implementation. If a scheduled job is missing from the scheduler, it is automatically re-scheduled.

ℹ️ The tests and documentation will be done after some feedback on the current implementation has been received.

---
I have currently implemented a temporary solution for the Quartz implementation of `isJobScheduled`:

When a `CancellationKey` is provided, the job is created with that key as the Quartz JobKey.
Quartz jobs are only directly retrievable by a JobKey. For scheduled jobs without a `CancellationKey`, a direct lookup is not possible by the `jobIdentifier`. Therefore `isJobScheduled` iterates over all job keys and inspects `JobDataMap` for the `jobIdentifier`.
Implementation snippet for reference:
```kotlin
override fun isJobScheduled(schedulingReference: SchedulingReference): Boolean {
    return getScheduledJobKeys().any { jobKey ->
        val job = scheduler.getJobDetail(jobKey) ?: return@any false
        val jobId = job.jobDataMap["jobIdentifier"] as? String

        jobId == schedulingReference.jobIdentifier.value
    }
}
```