### PR TITLE
#145 Importing data definitions - [I] - Allow importing `@Data` and their listeners

### DIFF
--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataListener.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataListener.kt
@@ -5,7 +5,7 @@ import de.lise.fluxflow.api.continuation.Continuation
 /**
  * A [DataListener] is a listener that is invoked whenever certain step data is updated.
  */
-interface DataListener<T> {
+interface DataListener<in T> {
     /**
      * The definition of this listener.
      */

--- a/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataListenerDefinition.kt
+++ b/library/core/api/src/main/kotlin/de/lise/fluxflow/api/step/stateful/data/DataListenerDefinition.kt
@@ -6,7 +6,7 @@ import de.lise.fluxflow.api.step.Step
  * A [DataListenerDefinition] defines a [DataListener] that can be used to listen for step data changes.
  * @param T The step data's model type.
  */
-interface DataListenerDefinition<T> {
+interface DataListenerDefinition<in T> {
     /**
      * Creates a new [DataListener] based on this definition.
      * @param step The owning step.

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/StepSpecificInstanceActivation.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/StepSpecificInstanceActivation.kt
@@ -81,8 +81,8 @@ class StepSpecificInstanceActivation<TWorkflowModel>(
             val relevantData: Map<String, Any?> = when(annotation.prefix) {
                 "" -> stepData.data
                 else -> stepData.data
-                    .filter { it.key.startsWith(annotation.prefix) }
-                    .mapKeys { it.key.removePrefix(annotation.prefix) }
+                    .filter { annotation.prefixStrategy.isPrefixed(annotation.prefix, it.key) }
+                    .mapKeys { annotation.prefixStrategy.remove(annotation.prefix, it.key) }
             }
             return BasicTypeActivator(
                 BasicFunctionResolver(

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/StepSpecificInstanceActivation.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/StepSpecificInstanceActivation.kt
@@ -3,6 +3,7 @@ package de.lise.fluxflow.engine.step
 import de.lise.fluxflow.api.ioc.IocProvider
 import de.lise.fluxflow.api.step.stateful.StepActivationException
 import de.lise.fluxflow.api.workflow.Workflow
+import de.lise.fluxflow.engine.step.data.ImportedDataResolver
 import de.lise.fluxflow.persistence.step.StepData
 import de.lise.fluxflow.reflection.activation.BasicTypeActivator
 import de.lise.fluxflow.reflection.activation.TypeActivator
@@ -11,38 +12,98 @@ import de.lise.fluxflow.reflection.activation.parameter.FixedValueParameterResol
 import de.lise.fluxflow.reflection.activation.parameter.IocParameterResolver
 import de.lise.fluxflow.reflection.activation.parameter.PriorityParameterResolver
 import de.lise.fluxflow.reflection.activation.parameter.ValueMatcher
+import de.lise.fluxflow.stereotyped.Import
 import kotlin.reflect.KClass
 
 class StepSpecificInstanceActivation<TWorkflowModel>(
     iocProvider: IocProvider,
     workflow: Workflow<TWorkflowModel>,
-    private val stepData: StepData
+    private val stepData: StepData,
 ) {
-    private val typeActivator: TypeActivator = BasicTypeActivator(
-        BasicFunctionResolver(
-            PriorityParameterResolver(
-                listOf(
-                    FixedValueParameterResolver(
-                        ValueMatcher.canBeAssigned(),
-                        workflow.model
-                    ),
-                    PriorityParameterResolver(stepData.data.map {
-                        FixedValueParameterResolver(
-                            ValueMatcher.hasName<Any?>(it.key)
-                                .and(ValueMatcher.canBeAssigned()),
-                            it.value
+    private val typeActivator = createTypeActivator(
+        iocProvider,
+        workflow,
+        stepData
+    )
+
+    fun <TInstance : Any> activateInstance(
+        type: KClass<TInstance>,
+    ): TInstance {
+        return typeActivator.findActivation(type)?.activate()
+            ?: throw StepActivationException(
+                stepData.id,
+                stepData.kind
+            )
+    }
+
+    private companion object {
+        fun <TWorkflowModel> createTypeActivator(
+            iocProvider: IocProvider,
+            workflow: Workflow<TWorkflowModel>,
+            stepData: StepData,
+        ): TypeActivator {
+            return BasicTypeActivator(
+                BasicFunctionResolver(
+                    PriorityParameterResolver(
+                        listOf(
+                            FixedValueParameterResolver(
+                                ValueMatcher.canBeAssigned(),
+                                workflow.model
+                            ),
+                            PriorityParameterResolver(stepData.data.map {
+                                FixedValueParameterResolver(
+                                    ValueMatcher.hasName<Any?>(it.key)
+                                        .and(ValueMatcher.canBeAssigned()),
+                                    it.value
+                                )
+                            }),
+                            IocParameterResolver(iocProvider),
+                            ImportedDataResolver { _, annotation ->
+                                createRecursiveTypeActivator(
+                                    iocProvider,
+                                    workflow,
+                                    stepData,
+                                    annotation,
+                                )
+                            }
                         )
-                    }),
-                    IocParameterResolver(iocProvider)
+                    )
                 )
             )
-        )
-    )
-    
-    fun <TInstance : Any> activateInstance(
-        type: KClass<TInstance>
-    ): TInstance {
-        return typeActivator.findActivation(type)?.activate() 
-            ?: throw StepActivationException(stepData.id, stepData.kind)
+        }
+        
+        fun <TWorkflowModel> createRecursiveTypeActivator(
+            iocProvider: IocProvider,
+            workflow: Workflow<TWorkflowModel>,
+            stepData: StepData,
+            annotation: Import
+        ): TypeActivator {
+            val relevantData: Map<String, Any?> = when(annotation.prefix) {
+                "" -> stepData.data
+                else -> stepData.data
+                    .filter { it.key.startsWith(annotation.prefix) }
+                    .mapKeys { it.key.removePrefix(annotation.prefix) }
+            }
+            return BasicTypeActivator(
+                BasicFunctionResolver(
+                    PriorityParameterResolver(
+                        listOf(
+                            FixedValueParameterResolver(
+                                ValueMatcher.canBeAssigned(),
+                                workflow.model
+                            ),
+                            PriorityParameterResolver(relevantData.map {
+                                FixedValueParameterResolver(
+                                    ValueMatcher.hasName<Any?>(it.key)
+                                        .and(ValueMatcher.canBeAssigned()),
+                                    it.value
+                                )
+                            }),
+                            IocParameterResolver(iocProvider),
+                        )
+                    )
+                )
+            )
+        }
     }
 }

--- a/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/ImportedDataResolver.kt
+++ b/library/core/engine/src/main/kotlin/de/lise/fluxflow/engine/step/data/ImportedDataResolver.kt
@@ -1,0 +1,31 @@
+package de.lise.fluxflow.engine.step.data
+
+import de.lise.fluxflow.reflection.activation.TypeActivator
+import de.lise.fluxflow.reflection.activation.parameter.FunctionParameter
+import de.lise.fluxflow.reflection.activation.parameter.ParameterResolution
+import de.lise.fluxflow.reflection.activation.parameter.ParameterResolver
+import de.lise.fluxflow.reflection.activation.parameter.RecursiveParameterResolver
+import de.lise.fluxflow.reflection.property.findAnnotationEverywhere
+import de.lise.fluxflow.stereotyped.Import
+import kotlin.reflect.full.findAnnotation
+
+class ImportedDataResolver(
+    private val typeResolverFactory: (
+        functionParam: FunctionParameter<*>,
+        importAnnotation: Import,
+    ) -> TypeActivator,
+) : ParameterResolver {
+    override fun resolveParameter(functionParam: FunctionParameter<*>): ParameterResolution? {
+        val annotation = (
+            functionParam.param.findAnnotation<Import>()
+                ?: functionParam.matchingProperty?.findAnnotationEverywhere<Import>()
+            ) ?: return null
+
+        return RecursiveParameterResolver(
+            typeResolverFactory(
+                functionParam,
+                annotation
+            )
+        ).resolveParameter(functionParam)
+    }
+}

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
@@ -1,0 +1,89 @@
+package de.lise.fluxflow.engine.step
+
+import de.lise.fluxflow.api.ioc.IocProvider
+import de.lise.fluxflow.api.step.Status
+import de.lise.fluxflow.api.versioning.DefaultCompatibilityTester
+import de.lise.fluxflow.api.versioning.NoVersion
+import de.lise.fluxflow.api.versioning.VersionCompatibility
+import de.lise.fluxflow.api.workflow.Workflow
+import de.lise.fluxflow.persistence.step.StepData
+import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.continuation.ContinuationBuilder
+import de.lise.fluxflow.stereotyped.step.StepDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.action.ActionDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.data.DataDefinitionBuilder
+import de.lise.fluxflow.stereotyped.versioning.VersionBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class DefaultStepActivationServiceIT {
+
+    @Test
+    fun `activateFromPersistence should be able to activate steps with simple imported data definitions`() {
+        val stepData = StepData(
+            id = "step-id",
+            workflowId = "workflow-id",
+            kind = TestStepWithImportedData::class.java.canonicalName,
+            version = null,
+            data = mapOf(
+                "someProperty" to "Hello World"
+            ),
+            status = Status.Active,
+            metadata = emptyMap()
+        )
+
+        val activationService = DefaultStepActivationService(
+            iocProvider,
+            StepDefinitionBuilder(
+                mockedVersionBuilder,
+                ActionDefinitionBuilder(
+                    mockedContinuationBuilder,
+                    mock {},
+                    mock {}
+                ),
+                DataDefinitionBuilder(
+                    mock {},
+                    mock {},
+                    mock {}
+                ),
+                mock {},
+                mock {},
+                mutableMapOf()
+            ),
+            StepTypeResolverImpl(TestStepWithImportedData::class.java.classLoader),
+            VersionCompatibility.Unknown,
+            DefaultCompatibilityTester()
+        )
+
+        val workflow = mock<Workflow<Any>> { }
+
+        // Act
+        val result = activationService.activateFromPersistence(
+            workflow,
+            stepData
+        )
+
+        // Assert
+        assertThat(result).isNotNull()
+    }
+
+    private val mockedVersionBuilder = mock<VersionBuilder> {
+        on { build(any()) } doReturn NoVersion()
+    }
+
+    private val mockedContinuationBuilder = mock<ContinuationBuilder> { }
+
+    private val iocProvider = mock<IocProvider> {}
+}
+
+data class ImportableTestModel(
+    var someProperty: String
+)
+
+data class TestStepWithImportedData(
+    @Import
+    val importedProperty: ImportableTestModel
+)

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
@@ -2,6 +2,8 @@ package de.lise.fluxflow.engine.step
 
 import de.lise.fluxflow.api.ioc.IocProvider
 import de.lise.fluxflow.api.step.Status
+import de.lise.fluxflow.api.step.stateful.StatefulStep
+import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.versioning.DefaultCompatibilityTester
 import de.lise.fluxflow.api.versioning.NoVersion
 import de.lise.fluxflow.api.versioning.VersionCompatibility
@@ -20,9 +22,10 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 class DefaultStepActivationServiceIT {
-
     @Test
     fun `activateFromPersistence should be able to activate steps with simple imported data definitions`() {
+        val workflow = mock<Workflow<Any>> { }
+        val activationService = createActivationService()
         val stepData = StepData(
             id = "step-id",
             workflowId = "workflow-id",
@@ -34,32 +37,7 @@ class DefaultStepActivationServiceIT {
             status = Status.Active,
             metadata = emptyMap()
         )
-
-        val activationService = DefaultStepActivationService(
-            iocProvider,
-            StepDefinitionBuilder(
-                mockedVersionBuilder,
-                ActionDefinitionBuilder(
-                    mockedContinuationBuilder,
-                    mock {},
-                    mock {}
-                ),
-                DataDefinitionBuilder(
-                    mock {},
-                    mock {},
-                    mock {}
-                ),
-                mock {},
-                mock {},
-                mutableMapOf()
-            ),
-            StepTypeResolverImpl(TestStepWithImportedData::class.java.classLoader),
-            VersionCompatibility.Unknown,
-            DefaultCompatibilityTester()
-        )
-
-        val workflow = mock<Workflow<Any>> { }
-
+        
         // Act
         val result = activationService.activateFromPersistence(
             workflow,
@@ -70,12 +48,63 @@ class DefaultStepActivationServiceIT {
         assertThat(result).isNotNull()
     }
 
+    @Test
+    fun `activateFromPersistence should be able to activate steps with prefixed imported data definitions`() {
+        val workflow = mock<Workflow<Any>> { }
+        val activationService = createActivationService()
+        val stepData = StepData(
+            id = "step-id",
+            workflowId = "workflow-id",
+            kind = TestStepWithPrefixedImportedData::class.java.canonicalName,
+            version = null,
+            data = mapOf(
+                "subsomeProperty" to "The answer is 42"
+            ),
+            status = Status.Active,
+            metadata = emptyMap()
+        )
+
+        // Act
+        val result = activationService.activateFromPersistence(
+            workflow,
+            stepData
+        )
+
+        // Assert
+        val data = (result as? StatefulStep)?.data?.single { 
+            it.definition.kind == DataKind("subsomeProperty") 
+        }
+        assertThat(data).isNotNull()
+        assertThat(data!!.get()).isEqualTo("The answer is 42")
+    }
+
+    private fun createActivationService(): DefaultStepActivationService = DefaultStepActivationService(
+        iocProvider,
+        StepDefinitionBuilder(
+            mockedVersionBuilder,
+            ActionDefinitionBuilder(
+                mockedContinuationBuilder,
+                mock {},
+                mock {}
+            ),
+            DataDefinitionBuilder(
+                mock {},
+                mock {},
+                mock {}
+            ),
+            mock {},
+            mock {},
+            mutableMapOf()
+        ),
+        StepTypeResolverImpl(TestStepWithImportedData::class.java.classLoader),
+        VersionCompatibility.Unknown,
+        DefaultCompatibilityTester()
+    )
+
     private val mockedVersionBuilder = mock<VersionBuilder> {
         on { build(any()) } doReturn NoVersion()
     }
-
     private val mockedContinuationBuilder = mock<ContinuationBuilder> { }
-
     private val iocProvider = mock<IocProvider> {}
 }
 
@@ -85,5 +114,10 @@ data class ImportableTestModel(
 
 data class TestStepWithImportedData(
     @Import
+    val importedProperty: ImportableTestModel
+)
+
+data class TestStepWithPrefixedImportedData(
+    @Import("sub")
     val importedProperty: ImportableTestModel
 )

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
@@ -71,8 +71,8 @@ class DefaultStepActivationServiceIT {
         )
 
         // Assert
-        val data = (result as? StatefulStep)?.data?.single { 
-            it.definition.kind == DataKind("subsomeProperty") 
+        val data = (result as? StatefulStep)?.data?.single {
+            it.definition.kind == DataKind("subSomeProperty")
         }
         assertThat(data).isNotNull()
         assertThat(data!!.get()).isEqualTo("The answer is 42")

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/DefaultStepActivationServiceIT.kt
@@ -58,7 +58,7 @@ class DefaultStepActivationServiceIT {
             kind = TestStepWithPrefixedImportedData::class.java.canonicalName,
             version = null,
             data = mapOf(
-                "subsomeProperty" to "The answer is 42"
+                "subSomeProperty" to "The answer is 42"
             ),
             status = Status.Active,
             metadata = emptyMap()

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
@@ -265,4 +265,28 @@ class StepIT {
         assertThat(newName.get()).isEqualTo("Arthur Dent")
         assertThat(wasUpdated.get()).isTrue()
     }
+
+    @Test
+    fun `listeners defined on the importing step should be invoked when updating imported data`() {
+        // Arrange
+        val workflow = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(
+                TestStepWithImportAndParentListener(
+                    TestDataToBeImported("Ford Prefect")
+                )
+            )
+        )
+        val step = stepService!!.findSteps(workflow).first() as StatefulStep
+        val nameData: Data<String> = step.data.single { it.definition.kind == DataKind("name") } as Data<String>
+
+        // Act
+        stepDataService.setValue(nameData, "Arthur Dent")
+
+        // Assert
+        val wasImportedNameUpdated = stepDataService.getData<Boolean>(step, DataKind("nameWasUpdatedToArthurDent"))
+        val parentListenerTriggered = stepDataService.getData<Boolean>(step, DataKind("parentListenerTriggered"))
+        assertThat(wasImportedNameUpdated.get()).isTrue()
+        assertThat(parentListenerTriggered.get()).isTrue()
+    }
 }

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
@@ -17,7 +17,6 @@ import de.lise.fluxflow.api.workflow.WorkflowStarterService
 import de.lise.fluxflow.engine.IntegrationTestConfig
 import de.lise.fluxflow.query.filter.Filter
 import de.lise.fluxflow.springboot.testing.TestingConfiguration
-import de.lise.fluxflow.stereotyped.step.StepDefinitionBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -38,9 +37,6 @@ class StepIT {
 
     @Autowired
     var actionService: ActionService? = null
-
-    @Autowired
-    lateinit var stepDefinitionBuilder: StepDefinitionBuilder
 
     @Autowired
     lateinit var stepDataService: StepDataService

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/StepIT.kt
@@ -10,10 +10,14 @@ import de.lise.fluxflow.api.step.query.filter.StepFilter
 import de.lise.fluxflow.api.step.query.filter.StepKindFilter
 import de.lise.fluxflow.api.step.stateful.StatefulStep
 import de.lise.fluxflow.api.step.stateful.action.ActionService
+import de.lise.fluxflow.api.step.stateful.data.Data
+import de.lise.fluxflow.api.step.stateful.data.DataKind
+import de.lise.fluxflow.api.step.stateful.data.StepDataService
 import de.lise.fluxflow.api.workflow.WorkflowStarterService
 import de.lise.fluxflow.engine.IntegrationTestConfig
 import de.lise.fluxflow.query.filter.Filter
 import de.lise.fluxflow.springboot.testing.TestingConfiguration
+import de.lise.fluxflow.stereotyped.step.StepDefinitionBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,20 +32,40 @@ import org.springframework.boot.test.context.SpringBootTest
 class StepIT {
     @Autowired
     var workflowStarterService: WorkflowStarterService? = null
+
     @Autowired
     var stepService: StepService? = null
+
     @Autowired
     var actionService: ActionService? = null
+
+    @Autowired
+    lateinit var stepDefinitionBuilder: StepDefinitionBuilder
+
+    @Autowired
+    lateinit var stepDataService: StepDataService
 
     @Test
     fun `findSteps with workflow and query should only include steps from a given workflow`() {
         // Arrange
-        val workflow1 = workflowStarterService!!.start(Any(), Continuation.step(TestStep()))
-        val workflow2 = workflowStarterService!!.start(Any(), Continuation.step(TestStep()))
+        val workflow1 = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(TestStep())
+        )
+        val workflow2 = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(TestStep())
+        )
 
         // Act
-        val stepsFromWorkflow1 = stepService!!.findSteps(workflow1, StepQuery.empty())
-        val stepsFromWorkflow2 = stepService!!.findSteps(workflow2, StepQuery.empty())
+        val stepsFromWorkflow1 = stepService!!.findSteps(
+            workflow1,
+            StepQuery.empty()
+        )
+        val stepsFromWorkflow2 = stepService!!.findSteps(
+            workflow2,
+            StepQuery.empty()
+        )
 
         // Assert
         stepsFromWorkflow1.items.forEach {
@@ -55,7 +79,10 @@ class StepIT {
     @Test
     fun `steps should not be completed if the continuation is set to preserve the step status`() {
         // Arrange
-        val workflow = workflowStarterService!!.start(Any(), Continuation.step(TestStepWithActions()))
+        val workflow = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(TestStepWithActions())
+        )
         val stepBeforeAction = stepService!!.findSteps(workflow).first()
         val action = (stepBeforeAction as StatefulStep).actions.first {
             it.definition.kind.value == TestStepWithActions::doSomethingAndPreserveStepStatus.name
@@ -65,14 +92,20 @@ class StepIT {
         actionService!!.invokeAction(action)
 
         // Assert
-        val stepAfterAction = stepService!!.findStep(workflow, stepBeforeAction.identifier)!!
+        val stepAfterAction = stepService!!.findStep(
+            workflow,
+            stepBeforeAction.identifier
+        )!!
         assertThat(stepAfterAction.status).isEqualTo(Status.Active)
     }
 
     @Test
     fun `steps should be completed if the continuation is set not to preserve the step status`() {
         // Arrange
-        val workflow = workflowStarterService!!.start(Any(), Continuation.step(TestStepWithActions()))
+        val workflow = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(TestStepWithActions())
+        )
         val stepBeforeAction = stepService!!.findSteps(workflow).first()
         val action = (stepBeforeAction as StatefulStep).actions.first {
             it.definition.kind.value == TestStepWithActions::doSomethingAndCompleteStep.name
@@ -82,14 +115,20 @@ class StepIT {
         actionService!!.invokeAction(action)
 
         // Assert
-        val stepAfterAction = stepService!!.findStep(workflow, stepBeforeAction.identifier)!!
+        val stepAfterAction = stepService!!.findStep(
+            workflow,
+            stepBeforeAction.identifier
+        )!!
         assertThat(stepAfterAction.status).isEqualTo(Status.Completed)
     }
 
     @Test
     fun `returning multiple continuations should be properly scheduled`() {
         // Arrange
-        val workflow = workflowStarterService!!.start(Any(), Continuation.step(TestStepWithMultiContinuation()))
+        val workflow = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(TestStepWithMultiContinuation())
+        )
         val stepWithMultiContinuation = stepService!!.findSteps(workflow).first()
         val action = (stepWithMultiContinuation as StatefulStep).actions.first {
             it.definition.kind.value == TestStepWithMultiContinuation::run.name
@@ -101,39 +140,41 @@ class StepIT {
         // Assert
         val stepsAfterActions = stepService!!.findSteps(
             workflow,
-            StepQuery.withFilter(StepFilter(
-                id = null,
-                definition = StepDefinitionFilter(
-                    kind = StepKindFilter.eq(StepKind(TestStep::class.qualifiedName!!))
-                ),
-                status = Filter.eq(Status.Active),
-                metadata = null
-            ))
+            StepQuery.withFilter(
+                StepFilter(
+                    id = null,
+                    definition = StepDefinitionFilter(
+                        kind = StepKindFilter.eq(StepKind(TestStep::class.qualifiedName!!))
+                    ),
+                    status = Filter.eq(Status.Active),
+                    metadata = null
+                )
+            )
         ).items
 
         assertThat(stepsAfterActions).hasSize(2)
     }
-    
+
     @Test
     fun `onCreated automation functions triggered by a multiple continuation should be executed together`() {
         // Arrange
         val step1 = TestStepWithConsolidatedOnCreatedExecution()
         val step2 = TestStepWithConsolidatedOnCreatedExecution()
-        
+
         // Act
         workflowStarterService!!.start(
-            Any(), 
+            Any(),
             Continuation.multiple(
                 Continuation.step(step1),
                 Continuation.step(step2)
             )
         )
-        
+
         // Assert
         assertThat(step1.steps).hasSize(2)
         assertThat(step2.steps).hasSize(2)
     }
-    
+
     @Test
     fun `StepService's setMetadata function should update a step's metadata`() {
         // Arrange
@@ -143,26 +184,44 @@ class StepIT {
             Continuation.step(stepDefinition)
         )
         val step = stepService!!.findSteps(workflow).first()
-        
+
         // Act
-        val addedMetadata = stepService!!.setMetadata(step, "fromCode", true)
-        val replacedMetadata = stepService!!.setMetadata(addedMetadata, "testMetadata", "from-code")
-        val removedMetadata = stepService!!.setMetadata(replacedMetadata, "testMetadata", null)
-        
+        val addedMetadata = stepService!!.setMetadata(
+            step,
+            "fromCode",
+            true
+        )
+        val replacedMetadata = stepService!!.setMetadata(
+            addedMetadata,
+            "testMetadata",
+            "from-code"
+        )
+        val removedMetadata = stepService!!.setMetadata(
+            replacedMetadata,
+            "testMetadata",
+            null
+        )
+
         // Assert
-        assertThat(addedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(mapOf(
-            "fromCode" to true,
-            "testMetadata" to "from-annotation"
-        ))
-        assertThat(replacedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(mapOf(
-            "fromCode" to true,
-            "testMetadata" to "from-code"
-        ))
-        assertThat(removedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(mapOf(
-            "fromCode" to true
-        ))
+        assertThat(addedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                "fromCode" to true,
+                "testMetadata" to "from-annotation"
+            )
+        )
+        assertThat(replacedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                "fromCode" to true,
+                "testMetadata" to "from-code"
+            )
+        )
+        assertThat(removedMetadata.metadata).containsExactlyInAnyOrderEntriesOf(
+            mapOf(
+                "fromCode" to true
+            )
+        )
     }
-    
+
     @Test
     fun `activating steps having a custom kind should succeed`() {
         // Arrange
@@ -171,11 +230,43 @@ class StepIT {
             Any(),
             Continuation.step(stepDefinition)
         )
-        
+
         // Act
         val step = stepService!!.findSteps(workflow).first()
-        
+
         // Assert
         assertThat(step).isNotNull
+    }
+
+    @Test
+    fun `updateListeners should be supported for imported data definitions`() {
+        // Arrange
+        val workflow = workflowStarterService!!.start(
+            Any(),
+            Continuation.step(
+                TestStepWithImport(
+                    TestDataToBeImported(
+                        "Marvin the robot"
+                    )
+                )
+            )
+        )
+        val step = stepService!!.findSteps(workflow).first()
+        val data: Data<String> = (step as StatefulStep).data.single {
+            it.definition.kind == DataKind("name")
+        } as Data<String>
+        
+        // Act
+        stepDataService.setValue(data, "Arthur Dent")
+        
+        // Assert
+        val newName = stepDataService.getData<String>(step, DataKind("name"))
+        val wasUpdated = stepDataService.getData<Boolean>(
+            step,
+            DataKind("nameWasUpdatedToArthurDent")
+        )
+        
+        assertThat(newName.get()).isEqualTo("Arthur Dent")
+        assertThat(wasUpdated.get()).isTrue()
     }
 }

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestDataToBeImported.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestDataToBeImported.kt
@@ -1,0 +1,16 @@
+package de.lise.fluxflow.engine.step
+
+import de.lise.fluxflow.stereotyped.step.data.DataListener
+
+data class TestDataToBeImported(
+    var name: String,
+) {
+
+    var nameWasUpdatedToArthurDent: Boolean? = null
+        private set
+
+    @DataListener("name")
+    fun onNameUpdate(oldValue: String, newValue: String) {
+        nameWasUpdatedToArthurDent = newValue == "Arthur Dent"
+    }
+}

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImport.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImport.kt
@@ -1,0 +1,24 @@
+package de.lise.fluxflow.engine.step
+
+import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.step.Step
+import de.lise.fluxflow.stereotyped.step.data.DataListener
+
+@Step
+class TestStepWithImport(
+    @Import
+    val importedInformation: TestDataToBeImported 
+)
+
+data class TestDataToBeImported(
+    var name: String,
+) {
+    
+    var nameWasUpdatedToArthurDent: Boolean? = null
+        private set
+    
+    @DataListener("name")
+    fun onNameUpdate(oldValue: String, newValue: String) {
+        nameWasUpdatedToArthurDent = newValue == "Arthur Dent"
+    }
+}

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImport.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImport.kt
@@ -2,23 +2,9 @@ package de.lise.fluxflow.engine.step
 
 import de.lise.fluxflow.stereotyped.Import
 import de.lise.fluxflow.stereotyped.step.Step
-import de.lise.fluxflow.stereotyped.step.data.DataListener
 
 @Step
 class TestStepWithImport(
     @Import
     val importedInformation: TestDataToBeImported 
 )
-
-data class TestDataToBeImported(
-    var name: String,
-) {
-    
-    var nameWasUpdatedToArthurDent: Boolean? = null
-        private set
-    
-    @DataListener("name")
-    fun onNameUpdate(oldValue: String, newValue: String) {
-        nameWasUpdatedToArthurDent = newValue == "Arthur Dent"
-    }
-}

--- a/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImportAndParentListener.kt
+++ b/library/core/engine/src/test/kotlin/de/lise/fluxflow/engine/step/TestStepWithImportAndParentListener.kt
@@ -1,0 +1,17 @@
+package de.lise.fluxflow.engine.step
+
+import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.step.Step
+import de.lise.fluxflow.stereotyped.step.data.DataListener
+
+@Step
+class TestStepWithImportAndParentListener(
+    @Import
+    val importedInformation: TestDataToBeImported,
+    var parentListenerTriggered: Boolean = false
+) {
+    @DataListener("name")
+    fun onImportedNameUpdate(oldValue: String?, newValue: String?) {
+        parentListenerTriggered = true
+    }
+}

--- a/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/FunctionExtensionFunctions.kt
+++ b/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/FunctionExtensionFunctions.kt
@@ -2,7 +2,10 @@ package de.lise.fluxflow.reflection
 
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
+import kotlin.reflect.full.instanceParameter
+import kotlin.reflect.jvm.javaConstructor
 
 fun <T> KFunction<T>.isInvokableInstanceFunction(): Boolean {
     return this.visibility == KVisibility.PUBLIC && !this.isAbstract
@@ -11,3 +14,10 @@ fun <T> KFunction<T>.isInvokableInstanceFunction(): Boolean {
 fun <T> KFunction<T>.hasAdditionalParameters(): Boolean {
     return this.parameters.any{ it.kind != KParameter.Kind.INSTANCE }
 }
+
+val <T> KFunction<T>.declaringType: KType?
+    get() = when {
+        javaConstructor != null -> returnType
+        instanceParameter != null -> instanceParameter?.type
+        else -> null
+    }

--- a/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/activation/parameter/FunctionParameter.kt
+++ b/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/activation/parameter/FunctionParameter.kt
@@ -1,9 +1,22 @@
 package de.lise.fluxflow.reflection.activation.parameter
 
+import de.lise.fluxflow.reflection.declaringType
+import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
 
 data class FunctionParameter<T>(
     val function: KFunction<T>,
     val param: KParameter
-)
+) {
+    val matchingProperty: KProperty1<*,*>? = when (param.name) {
+        null -> null
+        else -> (function.declaringType?.classifier as? KClass<*>)
+            ?.memberProperties
+            ?.firstOrNull { property ->
+                property.name == param.name
+            }
+    }
+}

--- a/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/activation/parameter/RecursiveParameterResolver.kt
+++ b/library/core/reflection/src/main/kotlin/de/lise/fluxflow/reflection/activation/parameter/RecursiveParameterResolver.kt
@@ -1,0 +1,17 @@
+package de.lise.fluxflow.reflection.activation.parameter
+
+import de.lise.fluxflow.reflection.activation.TypeActivator
+import kotlin.reflect.KClass
+
+class RecursiveParameterResolver(
+    private val typeResolver: TypeActivator,
+) : ParameterResolver {
+    override fun resolveParameter(functionParam: FunctionParameter<*>): ParameterResolution? {
+        val parameterClass = (functionParam.param.type.classifier as? KClass<*>) ?: return null
+        val activation = typeResolver.findActivation(parameterClass) ?: return null
+
+        return ParameterResolution {
+            activation.activate()
+        }
+    }
+}

--- a/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/FunctionExtensionFunctionsTest.kt
+++ b/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/FunctionExtensionFunctionsTest.kt
@@ -1,0 +1,31 @@
+package de.lise.fluxflow.reflection
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.typeOf
+
+class FunctionExtensionFunctionsTest {
+    @Test
+    fun `declaringType should return the declaring type for constructor functions`() {
+        // Act
+        val result = TestClass::class.constructors.single().declaringType
+        
+        // Assert
+        assertThat(result).isEqualTo(typeOf<TestClass>())
+    }
+
+    @Test
+    fun `declaringType should return the declaring type for member functions`() {
+        // Act
+        val result = TestClass::doSomething.declaringType
+
+        // Assert
+        assertThat(result).isEqualTo(typeOf<TestClass>())
+    }
+    
+    @Suppress("unused")
+    class TestClass {
+        constructor(someValue: Any)
+        fun doSomething() {}
+    }
+}

--- a/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/activation/parameter/FunctionParameterTest.kt
+++ b/library/core/reflection/src/test/kotlin/de/lise/fluxflow/reflection/activation/parameter/FunctionParameterTest.kt
@@ -1,0 +1,49 @@
+package de.lise.fluxflow.reflection.activation.parameter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FunctionParameterTest {
+    @Test
+    fun `matchingProperty should return KProperty created for default constructor`() {
+        // Arrange
+        val constructor = SomeDataClass::class.constructors.single()
+        val parameter = constructor.parameters.single { 
+            it.name == SomeDataClass::someProperty.name 
+        }
+        val functionParameter = FunctionParameter(constructor, parameter)
+    
+        // Act
+        val result = functionParameter.matchingProperty
+        
+        // Assert
+        assertThat(result).isEqualTo(SomeDataClass::someProperty)
+    }
+
+    @Test
+    fun `matchingProperty should return manually created properties`() {
+        // Arrange
+        val constructor = SomeClass::class.constructors.single()
+        val parameter = constructor.parameters.single {
+            it.name == SomeClass::someProperty.name
+        }
+        val functionParameter = FunctionParameter(constructor, parameter)
+
+        // Act
+        val result = functionParameter.matchingProperty
+
+        // Assert
+        assertThat(result).isEqualTo(SomeClass::someProperty)
+    }
+    
+    data class SomeDataClass(val someProperty: Any?)
+    
+    class SomeClass {
+        val someProperty: String
+        
+        @Suppress("unused")
+        constructor(someProperty: String) {
+            this.someProperty = someProperty
+        }
+    }
+}

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/Import.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/Import.kt
@@ -1,0 +1,49 @@
+package de.lise.fluxflow.stereotyped
+
+/**
+ * Annotation that enables importing and reusing data properties from another class into a step.
+ *
+ * When applied to a property in a step class, this annotation tells FluxFlow to import all
+ * declared elements (properties annotated with `@Data`) from the property's type and make
+ * them available as if they were directly declared on the step class.
+ *
+ * This feature allows developers to encapsulate common data structures and reuse them across
+ * multiple workflows, reducing code duplication and improving maintainability.
+ *
+ * ## Example
+ *
+ * ```kotlin
+ * data class EmployeeInformation(
+ *     @Data
+ *     val name: String,
+ *     @Data
+ *     val socialSecurityNumber: String
+ * )
+ *
+ * @Step
+ * class RequestVacationStep(
+ *     @Import
+ *     val employeeInformation: EmployeeInformation
+ * )
+ * ```
+ *
+ * The above example behaves exactly the same as:
+ *
+ * ```kotlin
+ * @Step
+ * class RequestVacationStep(
+ *     @Data
+ *     val name: String,
+ *     @Data
+ *     val socialSecurityNumber: String
+ * )
+ * ```
+ *
+ * @param prefix Optional prefix to add to imported property names to avoid naming conflicts.
+ *               When specified, all imported properties will be prefixed with this string.
+ */
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Import(
+    val prefix: String = ""
+)

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/Import.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/Import.kt
@@ -41,9 +41,12 @@ package de.lise.fluxflow.stereotyped
  *
  * @param prefix Optional prefix to add to imported property names to avoid naming conflicts.
  *               When specified, all imported properties will be prefixed with this string.
+ * @param prefixStrategy Specifies how the prefix parameter is interpreted and applied to the name to be prefixed.
+ * Defaults to [PrefixStrategy.CamelCase].
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Import(
-    val prefix: String = ""
+    val prefix: String = "",
+    val prefixStrategy: PrefixStrategy = PrefixStrategy.CamelCase
 )

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
@@ -1,0 +1,78 @@
+package de.lise.fluxflow.stereotyped
+
+import de.lise.fluxflow.stereotyped.PrefixStrategy.CamelCase
+import de.lise.fluxflow.stereotyped.PrefixStrategy.Plain
+
+/**
+ * Defines strategies for applying a prefix to imported names when using the [Import] annotation.
+ *
+ * This enum controls how the prefix is combined with the imported name:
+ *
+ * - [Plain]: Uses the prefix exactly as specified, without modification.
+ * - [CamelCase]: Adapts the prefix in camel case style to fit the imported name (capitalizes the first letter of the name).
+ *
+ * These strategies help avoid naming conflicts and improve code readability when importing elements from other classes or sources.
+ */
+enum class PrefixStrategy {
+    /**
+     * Uses the prefix exactly as specified, without modification.
+     *
+     * **Example:**
+     *
+     * | Prefix | Name | Result   |
+     * |--------|------|----------|
+     * | foo    | bar  | foobar   |
+     */
+    Plain,
+
+    /**
+     * Adapts the prefix in camel case style to fit the imported name (capitalizes the first letter of the name).
+     *
+     * **Example:**
+     *
+     * | Prefix | Name | Result   |
+     * |--------|------|----------|
+     * | foo    | bar  | fooBar   |
+     */
+    CamelCase;
+
+    /**
+     * Applies the prefix to the given name according to the selected strategy.
+     *
+     * @param prefix The prefix to apply.
+     * @param nameToBePrefixed The name to which the prefix should be applied.
+     * @return The resulting name with the prefix applied.
+     */
+    fun apply(
+        prefix: String,
+        nameToBePrefixed: String
+    ): String {
+        return when (this) {
+            Plain -> "$prefix$nameToBePrefixed"
+            CamelCase -> "$prefix${capitalize(nameToBePrefixed)}"
+        }
+    }
+
+    /**
+     * Removes the given prefix from the start of the provided name, if present.
+     *
+     * @param prefix The prefix to remove.
+     * @param prefixedName The name from which the prefix should be removed.
+     * @return The name without the prefix, or the original name if the prefix was not present.
+     */
+    fun remove(
+        prefix: String,
+        prefixedName: String
+    ): String {
+        return prefixedName.removePrefix(prefix)
+    }
+
+    
+    private fun capitalize(value: String): String {
+        return when (value.length) {
+            0 -> value
+            1 -> value.uppercase()
+            else -> "${value.take(1).uppercase()}${value.substring(1)}"
+        }
+    }
+}

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
@@ -87,7 +87,17 @@ enum class PrefixStrategy {
         value: String,
     ): Boolean {
         return when (this) {
-            else -> value.startsWith(prefix)
+            Plain -> value.startsWith(prefix)
+            CamelCase -> {
+                if (!value.startsWith(prefix)) {
+                    false
+                } else if (value.length > prefix.length) {
+                    val nextChar = value[prefix.length].toString()
+                    nextChar == nextChar.uppercase()
+                } else {
+                    false
+                }
+            }
         }
     }
 

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
@@ -47,6 +47,9 @@ enum class PrefixStrategy {
         prefix: String,
         nameToBePrefixed: String
     ): String {
+        if (prefix.isBlank()) {
+            return nameToBePrefixed
+        }
         return when (this) {
             Plain -> "$prefix$nameToBePrefixed"
             CamelCase -> "$prefix${capitalize(nameToBePrefixed)}"

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/PrefixStrategy.kt
@@ -45,7 +45,7 @@ enum class PrefixStrategy {
      */
     fun apply(
         prefix: String,
-        nameToBePrefixed: String
+        nameToBePrefixed: String,
     ): String {
         if (prefix.isBlank()) {
             return nameToBePrefixed
@@ -65,17 +65,45 @@ enum class PrefixStrategy {
      */
     fun remove(
         prefix: String,
-        prefixedName: String
+        prefixedName: String,
     ): String {
-        return prefixedName.removePrefix(prefix)
+        return when (this) {
+            Plain -> prefixedName.removePrefix(prefix)
+            CamelCase -> uncapitalize(
+                prefixedName.removePrefix(prefix)
+            )
+        }
     }
 
-    
+    /**
+     * Checks if the given value starts with the specified prefix according to the selected strategy.
+     *
+     * @param prefix The prefix to check for.
+     * @param value The value to check.
+     * @return True if the value starts with the prefix, false otherwise.
+     */
+    fun isPrefixed(
+        prefix: String,
+        value: String,
+    ): Boolean {
+        return when (this) {
+            else -> value.startsWith(prefix)
+        }
+    }
+
     private fun capitalize(value: String): String {
         return when (value.length) {
             0 -> value
             1 -> value.uppercase()
             else -> "${value.take(1).uppercase()}${value.substring(1)}"
+        }
+    }
+
+    private fun uncapitalize(value: String): String {
+        return when (value.length) {
+            0 -> value
+            1 -> value.lowercase()
+            else -> "${value.take(1).lowercase()}${value.substring(1)}"
         }
     }
 }

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/InstanceAccessor.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/InstanceAccessor.kt
@@ -1,0 +1,68 @@
+package de.lise.fluxflow.stereotyped.step
+
+import de.lise.fluxflow.api.step.Step
+
+/**
+ * An [InstanceAccessor] encapsulates the strategy for obtaining a concrete bound instance that backs a
+ * [Step].
+ *
+ * It allows reflective / indirect code (e.g. metadata builders) to read and optionally transform
+ * the instance associated with a step without needing to know how that instance is stored.
+ *
+ * Typical usage:
+ *  val accessor = InstanceAccessor.fromStepInstance<MyStepType>()
+ *  val stepInstance: MyStepType = accessor.get(step)
+ *
+ * You can derive further, typed accessors by chaining with [and]:
+ *  val nameAccessor = accessor.and { it.name }
+ *  val name: String = nameAccessor.get(step)
+ *
+ * Accessors are intentionally lightweight; composing them does not eagerly read the instance. Each
+ * call to [get] will retrieve the step instance and apply all mapper functions in order.
+ *
+ * @param TInstance The type of the instance this accessor returns.
+ */
+fun interface InstanceAccessor<out TInstance> {
+    /**
+     * Returns the bound instance for the given [step]. Implementations decide how the instance is
+     * retrieved (e.g. by calling `step.bind()` or accessing a cached value).
+     *
+     * @param step The step whose backing instance should be obtained.
+     * @return The backing instance.
+     */
+    fun get(step: Step): TInstance
+
+    /**
+     * Creates a new [InstanceAccessor] that maps the instance produced by the current accessor
+     * to another value using the provided [mapper].
+     *
+     * @param mapper A function that transforms the instance into another value.
+     * @return A new accessor that returns the mapped value.
+     */
+    fun <TOther> and(
+       mapper: (input: TInstance) -> TOther
+    ): InstanceAccessor<TOther> {
+        val current = this
+        return InstanceAccessor {
+            mapper(
+                current.get(it)
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * Creates an [InstanceAccessor] that retrieves the bound step instance via `Step.bind()`.
+         *
+         * This is the most common accessor used when the step instance itself is the root for
+         * further introspection.
+         *
+         * @return An accessor returning the bound instance of a step.
+         */
+        fun <TInstance> fromStepInstance(): InstanceAccessor<TInstance> {
+            return InstanceAccessor{
+                it.bind()!!
+            }
+        }
+    }
+}

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -2,6 +2,7 @@ package de.lise.fluxflow.stereotyped.step.data
 
 import de.lise.fluxflow.api.job.continuation.JobContinuation
 import de.lise.fluxflow.api.step.stateful.data.DataDefinition
+import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.step.stateful.data.ModifiableData
 import de.lise.fluxflow.api.step.stateful.data.ModificationPolicy
 import de.lise.fluxflow.reflection.ReflectionUtils
@@ -38,12 +39,14 @@ class DataDefinitionBuilder(
     ):  List<DataDefinition<*>> {
         return buildDataDefinition(
             type,
+            "",
             InstanceAccessor.fromStepInstance()
         )
     }
 
     private fun <TObject : Any> buildDataDefinition(
         type: KClass<TObject>,
+        kindPrefix: String,
         instanceAccessor: InstanceAccessor<TObject>
     ): List<DataDefinition<*>> {
         return type.memberProperties
@@ -51,6 +54,7 @@ class DataDefinitionBuilder(
                 buildDataDefinition(
                     type,
                     it,
+                    kindPrefix,
                     instanceAccessor
                 )
             }
@@ -59,11 +63,13 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinition(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, *>,
+        kindPrefix: String,
         instanceAccessor: InstanceAccessor<TObject>,
     ): List<DataDefinition<*>> {
-        prop.findAnnotationEverywhere<Import>()?.let {
+        prop.findAnnotationEverywhere<Import>()?.let { importAnnotation ->
             return buildImportedDataDefinition(
                 prop as KProperty1<TObject, Any>,
+                "$kindPrefix${importAnnotation.prefix}",
                 instanceAccessor
             )
         }
@@ -75,6 +81,7 @@ class DataDefinitionBuilder(
             buildDataDefinitionFromProperty(
                 instanceType,
                 prop,
+                kindPrefix,
                 instanceAccessor,
             )
         )
@@ -82,6 +89,7 @@ class DataDefinitionBuilder(
 
     private fun <TParentObject : Any, TProperty : Any> buildImportedDataDefinition(
         prop: KProperty1<TParentObject, TProperty>,
+        kindPrefix: String,
         parentInstanceAccessor: InstanceAccessor<TParentObject>
     ): List<DataDefinition<*>> {
         val returnType: KClass<TProperty> = ReflectionUtils.findReturnClass(prop)
@@ -92,6 +100,7 @@ class DataDefinitionBuilder(
 
         return buildDataDefinition(
             returnType,
+            kindPrefix,
             newInstanceAccessor
         )
     }
@@ -104,12 +113,14 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinitionFromProperty(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, *>,
+        kindPrefix: String,
         instanceAccessor: InstanceAccessor<TObject>,
     ): DataDefinition<*> {
         @Suppress("UNCHECKED_CAST")
         return buildDataDefinitionFromTypedProperty(
             instanceType,
             prop as KProperty1<TObject, Any>,
+            kindPrefix,
             instanceAccessor,
         )
     }
@@ -134,9 +145,12 @@ class DataDefinitionBuilder(
     private fun <TObject : Any, TProp : Any> buildDataDefinitionFromTypedProperty(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, TProp>,
+        kindPrefix: String,
         instanceAccessor: InstanceAccessor<TObject>
     ): DataDefinition<TProp?> {
-        val kind = DataKindInspector.getDataKind(prop)
+        val kind = DataKind(
+          "$kindPrefix${DataKindInspector.getDataKind(prop).value}"
+        )
         val modificationPolicy = prop.findAnnotationEverywhere<Data>()
             ?.modificationPolicy
             ?: ModificationPolicy.InheritSetting

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -6,6 +6,7 @@ import de.lise.fluxflow.api.step.stateful.data.ModifiableData
 import de.lise.fluxflow.api.step.stateful.data.ModificationPolicy
 import de.lise.fluxflow.reflection.ReflectionUtils
 import de.lise.fluxflow.reflection.property.findAnnotationEverywhere
+import de.lise.fluxflow.stereotyped.Import
 import de.lise.fluxflow.stereotyped.job.Job
 import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
 import de.lise.fluxflow.stereotyped.step.InstanceAccessor
@@ -42,7 +43,7 @@ class DataDefinitionBuilder(
     }
 
     private fun <TObject : Any> buildDataDefinition(
-        type: KClass<out TObject>,
+        type: KClass<TObject>,
         instanceAccessor: InstanceAccessor<TObject>
     ): List<DataDefinition<*>> {
         return type.memberProperties
@@ -56,10 +57,17 @@ class DataDefinitionBuilder(
     }
 
     private fun <TObject : Any> buildDataDefinition(
-        instanceType: KClass<out TObject>,
-        prop: KProperty1<out TObject, *>,
+        instanceType: KClass<TObject>,
+        prop: KProperty1<TObject, *>,
         instanceAccessor: InstanceAccessor<TObject>,
     ): List<DataDefinition<*>> {
+        prop.findAnnotationEverywhere<Import>()?.let {
+            return buildImportedDataDefinition(
+                prop as KProperty1<TObject, Any>,
+                instanceAccessor
+            )
+        }
+
         if (!isDataProperty(prop)) {
             return emptyList()
         }
@@ -72,14 +80,30 @@ class DataDefinitionBuilder(
         )
     }
 
+    private fun <TParentObject : Any, TProperty : Any> buildImportedDataDefinition(
+        prop: KProperty1<TParentObject, TProperty>,
+        parentInstanceAccessor: InstanceAccessor<TParentObject>
+    ): List<DataDefinition<*>> {
+        val returnType: KClass<TProperty> = ReflectionUtils.findReturnClass(prop)
+        val newInstanceAccessor: InstanceAccessor<TProperty> = parentInstanceAccessor.and {
+            val parent: TParentObject = it
+            prop.get(parent)
+        }
+
+        return buildDataDefinition(
+            returnType,
+            newInstanceAccessor
+        )
+    }
+
     /**
      * Introspects the given property and constructs a corresponding [DataDefinition] object.
      * @return A [Data] object backed by the given property.
      * If the property defines a setter, an instance of [ModifiableData] is returned.
      */
     private fun <TObject : Any> buildDataDefinitionFromProperty(
-        instanceType: KClass<out TObject>,
-        prop: KProperty1<out TObject, *>,
+        instanceType: KClass<TObject>,
+        prop: KProperty1<TObject, *>,
         instanceAccessor: InstanceAccessor<TObject>,
     ): DataDefinition<*> {
         @Suppress("UNCHECKED_CAST")
@@ -108,7 +132,7 @@ class DataDefinitionBuilder(
     }
 
     private fun <TObject : Any, TProp : Any> buildDataDefinitionFromTypedProperty(
-        instanceType: KClass<out TObject>,
+        instanceType: KClass<TObject>,
         prop: KProperty1<TObject, TProp>,
         instanceAccessor: InstanceAccessor<TObject>
     ): DataDefinition<TProp?> {

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -2,7 +2,6 @@ package de.lise.fluxflow.stereotyped.step.data
 
 import de.lise.fluxflow.api.job.continuation.JobContinuation
 import de.lise.fluxflow.api.step.stateful.data.DataDefinition
-import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.step.stateful.data.ModifiableData
 import de.lise.fluxflow.api.step.stateful.data.ModificationPolicy
 import de.lise.fluxflow.reflection.ReflectionUtils
@@ -11,6 +10,8 @@ import de.lise.fluxflow.stereotyped.Import
 import de.lise.fluxflow.stereotyped.job.Job
 import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
 import de.lise.fluxflow.stereotyped.step.InstanceAccessor
+import de.lise.fluxflow.stereotyped.step.data.KindPrefixBuilder.Companion.and
+import de.lise.fluxflow.stereotyped.step.data.KindPrefixBuilder.Companion.build
 import de.lise.fluxflow.stereotyped.step.data.validation.ValidationBuilder
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty1
@@ -39,14 +40,14 @@ class DataDefinitionBuilder(
     ):  List<DataDefinition<*>> {
         return buildDataDefinition(
             type,
-            "",
+            null,
             InstanceAccessor.fromStepInstance()
         )
     }
 
     private fun <TObject : Any> buildDataDefinition(
         type: KClass<TObject>,
-        kindPrefix: String,
+        kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>
     ): List<DataDefinition<*>> {
         return type.memberProperties
@@ -54,7 +55,7 @@ class DataDefinitionBuilder(
                 buildDataDefinition(
                     type,
                     it,
-                    kindPrefix,
+                    kindPrefixBuilder,
                     instanceAccessor
                 )
             }
@@ -63,13 +64,13 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinition(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, *>,
-        kindPrefix: String,
+        kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>,
     ): List<DataDefinition<*>> {
         prop.findAnnotationEverywhere<Import>()?.let { importAnnotation ->
             return buildImportedDataDefinition(
                 prop as KProperty1<TObject, Any>,
-                "$kindPrefix${importAnnotation.prefix}",
+                kindPrefixBuilder.and(importAnnotation),
                 instanceAccessor
             )
         }
@@ -81,7 +82,7 @@ class DataDefinitionBuilder(
             buildDataDefinitionFromProperty(
                 instanceType,
                 prop,
-                kindPrefix,
+                kindPrefixBuilder,
                 instanceAccessor,
             )
         )
@@ -89,7 +90,7 @@ class DataDefinitionBuilder(
 
     private fun <TParentObject : Any, TProperty : Any> buildImportedDataDefinition(
         prop: KProperty1<TParentObject, TProperty>,
-        kindPrefix: String,
+        kindPrefixBuilder: KindPrefixBuilder?,
         parentInstanceAccessor: InstanceAccessor<TParentObject>
     ): List<DataDefinition<*>> {
         val returnType: KClass<TProperty> = ReflectionUtils.findReturnClass(prop)
@@ -100,7 +101,7 @@ class DataDefinitionBuilder(
 
         return buildDataDefinition(
             returnType,
-            kindPrefix,
+            kindPrefixBuilder,
             newInstanceAccessor
         )
     }
@@ -113,14 +114,14 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinitionFromProperty(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, *>,
-        kindPrefix: String,
+        kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>,
     ): DataDefinition<*> {
         @Suppress("UNCHECKED_CAST")
         return buildDataDefinitionFromTypedProperty(
             instanceType,
             prop as KProperty1<TObject, Any>,
-            kindPrefix,
+            kindPrefixBuilder,
             instanceAccessor,
         )
     }
@@ -145,12 +146,10 @@ class DataDefinitionBuilder(
     private fun <TObject : Any, TProp : Any> buildDataDefinitionFromTypedProperty(
         instanceType: KClass<TObject>,
         prop: KProperty1<TObject, TProp>,
-        kindPrefix: String,
+        kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>
     ): DataDefinition<TProp?> {
-        val kind = DataKind(
-          "$kindPrefix${DataKindInspector.getDataKind(prop).value}"
-        )
+        val kind = kindPrefixBuilder.build(prop)
         val modificationPolicy = prop.findAnnotationEverywhere<Data>()
             ?.modificationPolicy
             ?: ModificationPolicy.InheritSetting
@@ -220,3 +219,4 @@ class DataDefinitionBuilder(
                 }
     }
 }
+

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -8,6 +8,7 @@ import de.lise.fluxflow.reflection.ReflectionUtils
 import de.lise.fluxflow.reflection.property.findAnnotationEverywhere
 import de.lise.fluxflow.stereotyped.job.Job
 import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
+import de.lise.fluxflow.stereotyped.step.InstanceAccessor
 import de.lise.fluxflow.stereotyped.step.data.validation.ValidationBuilder
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty1
@@ -27,31 +28,29 @@ class DataDefinitionBuilder(
     private val metadataBuilder: MetadataBuilder,
 ) {
     /**
-     * Checks if the given property should be interpreted as a [DataDefinition].
-     */
-    internal fun <TObject : Any> isDataProperty(
-        prop: KProperty1<out TObject, *>,
-    ): Boolean {
-        return prop.visibility == KVisibility.PUBLIC &&
-            ReflectionUtils.findReturnClass(prop).let { returnType ->
-                !returnType.hasAnnotation<Job>() &&
-                    !returnType.isSubclassOf(JobContinuation::class)
-            }
-    }
-
-    /**
      * Builds all data definitions that can be obtained by introspecting the given [type].
      * @param type The type to get data definitions from.
      * @return A list of all data definitions. If no data definition could be obtained, an empty list is returned.
      */
     fun <TObject : Any> buildDataDefinition(
         type: KClass<out TObject>,
+    ):  List<DataDefinition<*>> {
+        return buildDataDefinition(
+            type,
+            InstanceAccessor.fromStepInstance()
+        )
+    }
+
+    private fun <TObject : Any> buildDataDefinition(
+        type: KClass<out TObject>,
+        instanceAccessor: InstanceAccessor<TObject>
     ): List<DataDefinition<*>> {
         return type.memberProperties
             .flatMap {
                 buildDataDefinition(
                     type,
-                    it
+                    it,
+                    instanceAccessor
                 )
             }
     }
@@ -59,6 +58,7 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinition(
         instanceType: KClass<out TObject>,
         prop: KProperty1<out TObject, *>,
+        instanceAccessor: InstanceAccessor<TObject>,
     ): List<DataDefinition<*>> {
         if (!isDataProperty(prop)) {
             return emptyList()
@@ -66,7 +66,8 @@ class DataDefinitionBuilder(
         return listOf(
             buildDataDefinitionFromProperty(
                 instanceType,
-                prop
+                prop,
+                instanceAccessor,
             )
         )
     }
@@ -79,11 +80,13 @@ class DataDefinitionBuilder(
     private fun <TObject : Any> buildDataDefinitionFromProperty(
         instanceType: KClass<out TObject>,
         prop: KProperty1<out TObject, *>,
+        instanceAccessor: InstanceAccessor<TObject>,
     ): DataDefinition<*> {
         @Suppress("UNCHECKED_CAST")
         return buildDataDefinitionFromTypedProperty(
             instanceType,
-            prop as KProperty1<TObject, Any>
+            prop as KProperty1<TObject, Any>,
+            instanceAccessor,
         )
     }
 
@@ -107,6 +110,7 @@ class DataDefinitionBuilder(
     private fun <TObject : Any, TProp : Any> buildDataDefinitionFromTypedProperty(
         instanceType: KClass<out TObject>,
         prop: KProperty1<TObject, TProp>,
+        instanceAccessor: InstanceAccessor<TObject>
     ): DataDefinition<TProp?> {
         val kind = DataKindInspector.getDataKind(prop)
         val modificationPolicy = prop.findAnnotationEverywhere<Data>()
@@ -132,7 +136,7 @@ class DataDefinitionBuilder(
         if (modifiable) {
             @Suppress("UNCHECKED_CAST")
             val modifiableProperty = prop as KMutableProperty1<TObject, TProp?>
-            return ReflectedDataDefinition<TObject, TProp?>(
+            return ReflectedDataDefinition(
                 kind,
                 valueType,
                 metadata,
@@ -140,6 +144,7 @@ class DataDefinitionBuilder(
                 dataListenerDefinitions,
                 validations,
                 modificationPolicy,
+                instanceAccessor,
                 { instance -> prop.get(instance) },
                 { instance, newVal ->
                     modifiableProperty.set(
@@ -150,7 +155,7 @@ class DataDefinitionBuilder(
             )
         }
 
-        return ReflectedDataDefinition<TObject, TProp?>(
+        return ReflectedDataDefinition(
             kind,
             valueType,
             metadata,
@@ -158,7 +163,21 @@ class DataDefinitionBuilder(
             dataListenerDefinitions,
             validations,
             modificationPolicy,
+            instanceAccessor,
             { prop.get(it) }
         )
+    }
+
+    /**
+     * Checks if the given property should be interpreted as a [DataDefinition].
+     */
+    internal fun <TObject : Any> isDataProperty(
+        prop: KProperty1<out TObject, *>,
+    ): Boolean {
+        return prop.visibility == KVisibility.PUBLIC &&
+                ReflectionUtils.findReturnClass(prop).let { returnType ->
+                    !returnType.hasAnnotation<Job>() &&
+                            !returnType.isSubclassOf(JobContinuation::class)
+                }
     }
 }

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -161,7 +161,8 @@ class DataDefinitionBuilder(
         val dataListenerDefinitions = dataListenerDefinitionBuilder.build<TObject, TProp?>(
             kind,
             valueType,
-            instanceType
+            instanceType,
+            instanceAccessor
         ).toList()
         
         val validations = validationBuilder.buildValidations(

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilder.kt
@@ -49,7 +49,7 @@ class DataDefinitionBuilder(
         type: KClass<TObject>,
         kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>
-    ): List<DataDefinition<*>> {
+    ): List<ReflectedDataDefinition<*,*>> {
         return type.memberProperties
             .flatMap {
                 buildDataDefinition(
@@ -66,15 +66,15 @@ class DataDefinitionBuilder(
         prop: KProperty1<TObject, *>,
         kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>,
-    ): List<DataDefinition<*>> {
+    ): List<ReflectedDataDefinition<*,*>> {
         prop.findAnnotationEverywhere<Import>()?.let { importAnnotation ->
             return buildImportedDataDefinition(
+                instanceType,
                 prop as KProperty1<TObject, Any>,
                 kindPrefixBuilder.and(importAnnotation),
                 instanceAccessor
             )
         }
-
         if (!isDataProperty(prop)) {
             return emptyList()
         }
@@ -89,21 +89,31 @@ class DataDefinitionBuilder(
     }
 
     private fun <TParentObject : Any, TProperty : Any> buildImportedDataDefinition(
+        parentType: KClass<TParentObject>,
         prop: KProperty1<TParentObject, TProperty>,
         kindPrefixBuilder: KindPrefixBuilder?,
-        parentInstanceAccessor: InstanceAccessor<TParentObject>
-    ): List<DataDefinition<*>> {
+        parentInstanceAccessor: InstanceAccessor<TParentObject>,
+    ): List<ReflectedDataDefinition<*,*>> {
         val returnType: KClass<TProperty> = ReflectionUtils.findReturnClass(prop)
         val newInstanceAccessor: InstanceAccessor<TProperty> = parentInstanceAccessor.and {
             val parent: TParentObject = it
             prop.get(parent)
         }
-
-        return buildDataDefinition(
+        val importedDataDefinitions = buildDataDefinition(
             returnType,
             kindPrefixBuilder,
             newInstanceAccessor
         )
+        
+        return importedDataDefinitions.map { importedResult ->
+            val listenersFromImportingLocation = dataListenerDefinitionBuilder.build<TParentObject, Any?>(
+                importedResult.kind,
+                importedResult.type,
+                parentType,
+                parentInstanceAccessor
+            )
+            importedResult.withAdditionalListeners(listenersFromImportingLocation)
+        }
     }
 
     /**
@@ -116,7 +126,7 @@ class DataDefinitionBuilder(
         prop: KProperty1<TObject, *>,
         kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>,
-    ): DataDefinition<*> {
+    ): ReflectedDataDefinition<*,*> {
         @Suppress("UNCHECKED_CAST")
         return buildDataDefinitionFromTypedProperty(
             instanceType,
@@ -148,7 +158,7 @@ class DataDefinitionBuilder(
         prop: KProperty1<TObject, TProp>,
         kindPrefixBuilder: KindPrefixBuilder?,
         instanceAccessor: InstanceAccessor<TObject>
-    ): DataDefinition<TProp?> {
+    ): ReflectedDataDefinition<TObject, TProp?> {
         val kind = kindPrefixBuilder.build(prop)
         val modificationPolicy = prop.findAnnotationEverywhere<Data>()
             ?.modificationPolicy

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataKindInspector.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataKindInspector.kt
@@ -2,6 +2,8 @@ package de.lise.fluxflow.stereotyped.step.data
 
 import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.step.stateful.data.StepDataKind
+import de.lise.fluxflow.reflection.property.findAnnotationEverywhere
+import de.lise.fluxflow.stereotyped.Import
 import de.lise.fluxflow.stereotyped.step.StepKindInspector
 import kotlin.reflect.KProperty1
 import kotlin.reflect.jvm.javaField
@@ -10,12 +12,7 @@ import kotlin.reflect.jvm.javaGetter
 class DataKindInspector private constructor() {
     companion object {
         fun getDataKind(prop: KProperty1<*, *>): DataKind {
-            return prop.annotations
-                .find { it is Data }
-                ?.let { it as Data }?.identifier
-                ?.takeUnless { it.isBlank() }
-                ?.let { DataKind(it) }
-                ?: DataKind(prop.name)
+            return getDataKind(null, prop)
         }
 
         fun getStepDataKind(prop: KProperty1<*, *>): StepDataKind {
@@ -27,6 +24,34 @@ class DataKindInspector private constructor() {
                 ),
                 getDataKind(prop)
             )
+        }
+        
+        fun <TImportingProperty> getDataKind(
+            importingProperty: KProperty1<*, TImportingProperty>,
+            importedProperty: KProperty1<TImportingProperty, *>
+        ): DataKind {
+            return getDataKind(
+                importingProperty.findAnnotationEverywhere<Import>(),
+                importedProperty
+            )
+        }
+        
+        fun getDataKind(
+            importAnnotation: Import?,
+            prop: KProperty1<*,*>
+        ): DataKind {
+            val rawKind = prop.annotations
+                .find { it is Data }
+                ?.let { it as Data }?.identifier
+                ?.takeUnless { it.isBlank() }
+                ?: prop.name
+            
+            val finalKind = importAnnotation?.prefixStrategy?.apply(
+                importAnnotation.prefix,
+                rawKind
+            ) ?: rawKind
+            
+            return DataKind(finalKind)
         }
     }
 }

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataListenerDefinitionBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/DataListenerDefinitionBuilder.kt
@@ -5,6 +5,7 @@ import de.lise.fluxflow.api.step.stateful.data.DataListenerDefinition
 import de.lise.fluxflow.reflection.activation.parameter.ParameterResolver
 import de.lise.fluxflow.reflection.isInvokableInstanceFunction
 import de.lise.fluxflow.stereotyped.continuation.ContinuationBuilder
+import de.lise.fluxflow.stereotyped.step.InstanceAccessor
 import de.lise.fluxflow.stereotyped.step.action.ImplicitStatusBehavior
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
@@ -20,22 +21,24 @@ class DataListenerDefinitionBuilder(
         dataKind: DataKind,
         dataType: Type,
         instanceType: KClass<*>,
+        instanceAccessor: InstanceAccessor<TFunctionOwner>
     ): Set<DataListenerDefinition<TProp>> {
         return instanceType.functions
             .mapNotNull {
                 build<TFunctionOwner, TProp>(
                     dataKind,
                     dataType,
+                    instanceAccessor,
                     it
                 )
             }
             .toSet()
     }
-    
-    
+
     private fun <TFunctionOwner : Any, TProp> build(
         dataKind: DataKind,
         dataType: Type,
+        instanceAccessor: InstanceAccessor<TFunctionOwner>,
         function: KFunction<*>,
     ): DataListenerDefinition<TProp>? {
         if (!function.isInvokableInstanceFunction()) {
@@ -59,7 +62,9 @@ class DataListenerDefinitionBuilder(
             function
         )
 
-        return ReflectedDataListenerDefinition<TFunctionOwner, TProp> { step, instance, old, new ->
+        return ReflectedDataListenerDefinition(
+            instanceAccessor
+        ) { step, instance, old, new ->
             val callable = DataListenerFunctionResolver(
                 parameterResolver,
                 function,

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/KindPrefixBuilder.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/KindPrefixBuilder.kt
@@ -1,0 +1,48 @@
+package de.lise.fluxflow.stereotyped.step.data
+
+import de.lise.fluxflow.api.step.stateful.data.DataKind
+import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.PrefixStrategy
+import kotlin.reflect.KProperty1
+
+data class KindPrefixBuilder(
+    val strategy: PrefixStrategy,
+    val prefix: String,
+) {
+    fun apply(name: String): String {
+        return if (prefix.isBlank()) {
+            name
+        } else {
+            strategy.apply(
+                prefix,
+                name
+            )
+        }
+    }
+
+    companion object {
+        fun KindPrefixBuilder?.and(annotation: Import): KindPrefixBuilder? {
+            return when (this) {
+                null -> KindPrefixBuilder(
+                    annotation.prefixStrategy,
+                    annotation.prefix
+                )
+
+                else -> KindPrefixBuilder(
+                    annotation.prefixStrategy,
+                    strategy.apply(
+                        prefix,
+                        annotation.prefix
+                    )
+                )
+            }
+        }
+
+        fun KindPrefixBuilder?.build(prop: KProperty1<*, *>): DataKind {
+            val rawKind = DataKindInspector.getDataKind(prop).value
+            return DataKind(
+                value = this?.apply(rawKind) ?: rawKind
+            )
+        }
+    }
+}

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
@@ -4,7 +4,7 @@ import de.lise.fluxflow.api.step.Step
 import de.lise.fluxflow.api.step.stateful.data.*
 import de.lise.fluxflow.api.step.stateful.data.Data
 import de.lise.fluxflow.api.step.stateful.data.validation.DataValidationDefinition
-import de.lise.fluxflow.stereotyped.step.bind
+import de.lise.fluxflow.stereotyped.step.InstanceAccessor
 import java.lang.reflect.Type
 
 class ReflectedDataDefinition<TInstance, TModel>(
@@ -15,6 +15,7 @@ class ReflectedDataDefinition<TInstance, TModel>(
     override val updateListeners: List<DataListenerDefinition<TModel>>,
     override val validation: DataValidationDefinition?,
     override val modificationPolicy: ModificationPolicy,
+    private val instanceAccessor: InstanceAccessor<TInstance>,
     private val propertyGetter: PropertyGetter<TInstance, TModel>,
     private val propertySetter: PropertySetter<TInstance, TModel>? = null,
 ) : DataDefinition<TModel> {
@@ -22,7 +23,7 @@ class ReflectedDataDefinition<TInstance, TModel>(
         get() = propertySetter == null
 
     override fun createData(step: Step): Data<TModel> {
-        val instance = step.bind<TInstance>()!!
+        val instance = instanceAccessor.get(step)
         
         val readOnlyData = ReflectedData(
             step,

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataDefinition.kt
@@ -7,7 +7,7 @@ import de.lise.fluxflow.api.step.stateful.data.validation.DataValidationDefiniti
 import de.lise.fluxflow.stereotyped.step.InstanceAccessor
 import java.lang.reflect.Type
 
-class ReflectedDataDefinition<TInstance, TModel>(
+data class ReflectedDataDefinition<TInstance, TModel>(
     override val kind: DataKind,
     override val type: Type,
     override val metadata: Map<String, Any>,
@@ -22,6 +22,14 @@ class ReflectedDataDefinition<TInstance, TModel>(
     override val isReadonly: Boolean
         get() = propertySetter == null
 
+    internal fun withAdditionalListeners(
+        listeners: Collection<DataListenerDefinition<TModel>>
+    ): ReflectedDataDefinition<TInstance, TModel> {
+        return copy(
+            updateListeners = updateListeners + listeners
+        )
+    }
+    
     override fun createData(step: Step): Data<TModel> {
         val instance = instanceAccessor.get(step)
         

--- a/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataListenerDefinition.kt
+++ b/library/core/stereotyped/src/main/kotlin/de/lise/fluxflow/stereotyped/step/data/ReflectedDataListenerDefinition.kt
@@ -3,13 +3,14 @@ package de.lise.fluxflow.stereotyped.step.data
 import de.lise.fluxflow.api.step.Step
 import de.lise.fluxflow.api.step.stateful.data.DataListener
 import de.lise.fluxflow.api.step.stateful.data.DataListenerDefinition
-import de.lise.fluxflow.stereotyped.step.bind
+import de.lise.fluxflow.stereotyped.step.InstanceAccessor
 
 class ReflectedDataListenerDefinition<TInstance, TModel>(
-    private val callback: DataListenerCallback<TInstance, TModel>
+    private val instanceAccessor: InstanceAccessor<TInstance>,
+    private val callback: DataListenerCallback<TInstance, TModel>,
 ) : DataListenerDefinition<TModel> {
     override fun create(step: Step): DataListener<TModel> {
-        val instance = step.bind<TInstance>()!!
+        val instance = instanceAccessor.get(step)
         return ReflectedDataListener(
             step,
             this,

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
@@ -226,8 +226,14 @@ class DataDefinitionBuilderTest {
         assertThat(
             definitions.map { it.kind }
         ).contains(
-            DataKind("prefix.${DataKindInspector.getDataKind(SimpleImportableDataClass::name).value}"),
-            DataKind("prefix.${DataKindInspector.getDataKind(SimpleImportableDataClass::modifiableProperty).value}"),
+            DataKindInspector.getDataKind(
+                StepWithPrefixedImport::prefixedImportProperty,
+                SimpleImportableDataClass::name
+            ),
+            DataKindInspector.getDataKind(
+                StepWithPrefixedImport::prefixedImportProperty,
+                SimpleImportableDataClass::modifiableProperty
+            ),
         )
     }
 

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
@@ -211,7 +211,28 @@ class DataDefinitionBuilderTest {
     }
 
     @Test
-    fun `returned data definitions should be capable to get and set values`() {
+    fun `build should honor prefixes specified on @Import annotations`() {
+        // Arrange
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            listenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(StepWithPrefixedImport::class)
+
+        // Assert
+        assertThat(
+            definitions.map { it.kind }
+        ).contains(
+            DataKind("prefix.${DataKindInspector.getDataKind(SimpleImportableDataClass::name).value}"),
+            DataKind("prefix.${DataKindInspector.getDataKind(SimpleImportableDataClass::modifiableProperty).value}"),
+        )
+    }
+
+    @Test
+    fun `returned data definitions should be capable to get and set values for imported data definitions`() {
         // Arrange
         val instance = TestWithImport(
             importProperty = SimpleImportableDataClass(
@@ -364,5 +385,10 @@ class DataDefinitionBuilderTest {
         @de.lise.fluxflow.stereotyped.step.data.Data
         val name: String,
         var modifiableProperty: Boolean
+    )
+
+    data class StepWithPrefixedImport(
+        @Import("prefix.")
+        val prefixedImportProperty: SimpleImportableDataClass
     )
 }

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
@@ -4,6 +4,7 @@ import de.lise.fluxflow.api.step.stateful.data.Data
 import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.step.stateful.data.ModifiableData
 import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.continuation.ContinuationBuilder
 import de.lise.fluxflow.stereotyped.job.Job
 import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
 import de.lise.fluxflow.stereotyped.step.ReflectedStatefulStep
@@ -312,6 +313,75 @@ class DataDefinitionBuilderTest {
         assertThat(isDataProperty).isFalse
     }
 
+    @Test
+    fun `imported data definitions should include listeners defined on the importing step`() {
+        // Arrange
+        // We use a real DataListenerDefinitionBuilder to verify merging listeners from parent and imported type.
+        val realListenerDefinitionBuilder = DataListenerDefinitionBuilder(
+            ContinuationBuilder()
+        ) { null }
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            realListenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(ParentWithImportAndListeners::class)
+        val kind = DataKindInspector.getDataKind(ImportableWithListener::value)
+        val importedDefinition = definitions.first { it.kind == kind } as ReflectedDataDefinition<*, *>
+
+        // Assert
+        // Expect two listeners: one declared on imported type, one on parent type.
+        assertThat(importedDefinition.updateListeners).hasSize(2)
+    }
+
+    @Test
+    fun `prefixed imported data definitions should include listeners defined on the importing step using the prefixed kind`() {
+        // Arrange
+        val realListenerDefinitionBuilder = DataListenerDefinitionBuilder(
+            ContinuationBuilder()
+        ) { null }
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            realListenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(ParentWithPrefixedImportAndListener::class)
+        val kind = DataKindInspector.getDataKind(
+            ParentWithPrefixedImportAndListener::imported,
+            ImportableWithListener::value
+        )
+        val importedDefinition = definitions.first { it.kind == kind } as ReflectedDataDefinition<*, *>
+
+        // Assert
+        // Only one listener expected (defined on parent), since imported type does not know prefix.
+        assertThat(importedDefinition.updateListeners).hasSize(1)
+    }
+
+    @Test
+    fun `imported data definitions should only include listeners from imported type when parent defines none`() {
+        // Arrange
+        val realListenerDefinitionBuilder = DataListenerDefinitionBuilder(
+            ContinuationBuilder()
+        ) { null }
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            realListenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(ParentWithImportNoListener::class)
+        val kind = DataKindInspector.getDataKind(ImportableWithListener::value)
+        val importedDefinition = definitions.first { it.kind == kind } as ReflectedDataDefinition<*, *>
+
+        // Assert
+        assertThat(importedDefinition.updateListeners).hasSize(1)
+    }
+
     private fun <TObject : Any> mockReflectedStatefulStep(
         testInstance: TObject
     ): ReflectedStatefulStep {
@@ -396,5 +466,35 @@ class DataDefinitionBuilderTest {
     data class StepWithPrefixedImport(
         @Import("prefix.")
         val prefixedImportProperty: SimpleImportableDataClass
+    )
+
+    // Additional helper / fixture types for new tests
+    data class ImportableWithListener(
+        @de.lise.fluxflow.stereotyped.step.data.Data
+        val value: String
+    ) {
+        @DataListener("value")
+        fun onValueChanged(oldValue: String?, newValue: String?) { /* no-op for test */ }
+    }
+
+    class ParentWithImportAndListeners(
+        @Import
+        val imported: ImportableWithListener
+    ) {
+        @DataListener("value")
+        fun onImportedValueChanged(oldValue: String?, newValue: String?) { /* no-op for test */ }
+    }
+
+    class ParentWithPrefixedImportAndListener(
+        @Import("prefix")
+        val imported: ImportableWithListener
+    ) {
+        @DataListener("prefixValue")
+        fun onPrefixedImportedValueChanged(oldValue: String?, newValue: String?) { /* no-op for test */ }
+    }
+
+    class ParentWithImportNoListener(
+        @Import
+        val imported: ImportableWithListener
     )
 }

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/DataDefinitionBuilderTest.kt
@@ -1,7 +1,9 @@
 package de.lise.fluxflow.stereotyped.step.data
 
 import de.lise.fluxflow.api.step.stateful.data.Data
+import de.lise.fluxflow.api.step.stateful.data.DataKind
 import de.lise.fluxflow.api.step.stateful.data.ModifiableData
+import de.lise.fluxflow.stereotyped.Import
 import de.lise.fluxflow.stereotyped.job.Job
 import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
 import de.lise.fluxflow.stereotyped.step.ReflectedStatefulStep
@@ -90,7 +92,7 @@ class DataDefinitionBuilderTest {
             instance,
             ModifiableTestClass::modifiableStringProperty
         )
-            as ModifiableData<String>
+                as ModifiableData<String>
 
         // Act
         data.set("But what is the question?")
@@ -109,7 +111,7 @@ class DataDefinitionBuilderTest {
             instance,
             ModifiableTestClass::modifiableStringProperty
         )
-            as ModifiableData<String>
+                as ModifiableData<String>
 
         // Assert 
         assertThat(data.definition.isCalculatedValue).isFalse()
@@ -125,7 +127,7 @@ class DataDefinitionBuilderTest {
             instance,
             ModifiableTestClassWithOverwrittenIsCalculated::overwrittenProperty
         )
-            as ModifiableData<String>
+                as ModifiableData<String>
 
         // Assert 
         assertThat(data.definition.isCalculatedValue).isTrue()
@@ -141,10 +143,95 @@ class DataDefinitionBuilderTest {
             instance,
             TestClassWithCalculatedProperty::calculatedProperty
         )
-            as ModifiableData<String>
+                as ModifiableData<String>
 
         // Assert 
         assertThat(data.definition.isCalculatedValue).isTrue()
+    }
+
+    @Test
+    fun `build should include imported data definitions`() {
+        // Arrange
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            listenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(TestWithImport::class)
+
+        // Assert
+        assertThat(
+            definitions.map { it.kind }
+        ).contains(
+            DataKindInspector.getDataKind(SimpleImportableDataClass::name),
+            DataKindInspector.getDataKind(SimpleImportableDataClass::modifiableProperty)
+        )
+    }
+
+    @Test
+    fun `build should keep regular data definitions, even if others are imported`() {
+        // Arrange
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            listenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(TestWithImport::class)
+
+        // Assert
+        assertThat(
+            definitions.map { it.kind }
+        ).contains(
+            DataKindInspector.getDataKind(TestWithImport::regularDataDefinition)
+        )
+    }
+
+    @Test
+    fun `build should not recognize properties annotated with @Import as direct data definitions`() {
+        // Arrange
+        val dataDefinitionBuilder = DataDefinitionBuilder(
+            listenerDefinitionBuilder,
+            mock<ValidationBuilder> {},
+            mock<MetadataBuilder> {}
+        )
+
+        // Act
+        val definitions = dataDefinitionBuilder.buildDataDefinition(TestWithImport::class)
+
+        // Assert
+        assertThat(
+            definitions.map { it.kind }
+        ).doesNotContain(
+            DataKindInspector.getDataKind(TestWithImport::importProperty)
+        )
+    }
+
+    @Test
+    fun `returned data definitions should be capable to get and set values`() {
+        // Arrange
+        val instance = TestWithImport(
+            importProperty = SimpleImportableDataClass(
+                "name",
+                false
+            ),
+            regularDataDefinition = 42
+        )
+
+        // Act
+        val data = createDataObject<Boolean>(
+            instance,
+            DataKindInspector.getDataKind(SimpleImportableDataClass::modifiableProperty)
+        )
+        val originalValue = data.get()
+        (data as? ModifiableData<Boolean>)?.set(true)
+
+        // Assert
+        assertThat(originalValue).isFalse()
+        assertThat(instance.importProperty.modifiableProperty).isTrue()
     }
 
     @Test
@@ -198,20 +285,27 @@ class DataDefinitionBuilderTest {
         assertThat(isDataProperty).isFalse
     }
 
-    private fun <TObject : Any, TProp> createDataObject(
-        testInstance: TObject,
-        prop: KProperty1<out TObject, TProp>,
+    private fun <TObject : Any> mockReflectedStatefulStep(
+        testInstance: TObject
+    ): ReflectedStatefulStep {
+        val step = mock<ReflectedStatefulStep> {
+            on { instance } doReturn testInstance
+        }
+        return step
+    }
+
+    private fun <TProp> createDataObject(
+        testInstance: Any,
+        expectedKind: DataKind
     ): Data<TProp> {
+        val step = mockReflectedStatefulStep(testInstance)
+
         val dataDefinitionBuilder = DataDefinitionBuilder(
             listenerDefinitionBuilder,
             mock<ValidationBuilder> {},
             mock<MetadataBuilder> {}
         )
-        val step = mock<ReflectedStatefulStep> {
-            on { instance } doReturn testInstance
-        }
 
-        val expectedKind = DataKindInspector.getDataKind(prop)
 
         @Suppress("UNCHECKED_CAST")
         return dataDefinitionBuilder.buildDataDefinition(
@@ -219,6 +313,16 @@ class DataDefinitionBuilderTest {
         )
             .first { expectedKind == it.kind }
             .createData(step) as Data<TProp>
+    }
+
+    private fun <TObject : Any, TProp> createDataObject(
+        testInstance: TObject,
+        prop: KProperty1<out TObject, TProp>,
+    ): Data<TProp> {
+        return createDataObject(
+            testInstance,
+            DataKindInspector.getDataKind(prop),
+        )
     }
 
     class TestClass(
@@ -249,5 +353,16 @@ class DataDefinitionBuilderTest {
     class TestClassWithJobProp(
         val testJob: TestJob,
     )
-}
 
+    class TestWithImport(
+        @Import
+        val importProperty: SimpleImportableDataClass,
+        val regularDataDefinition: Int
+    )
+
+    data class SimpleImportableDataClass(
+        @de.lise.fluxflow.stereotyped.step.data.Data
+        val name: String,
+        var modifiableProperty: Boolean
+    )
+}

--- a/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/KindPrefixBuilderTest.kt
+++ b/library/core/stereotyped/src/test/kotlin/de/lise/fluxflow/stereotyped/step/data/KindPrefixBuilderTest.kt
@@ -1,0 +1,149 @@
+package de.lise.fluxflow.stereotyped.step.data
+
+import de.lise.fluxflow.api.step.stateful.data.DataKind
+import de.lise.fluxflow.stereotyped.Import
+import de.lise.fluxflow.stereotyped.PrefixStrategy
+import de.lise.fluxflow.stereotyped.step.data.KindPrefixBuilder.Companion.and
+import de.lise.fluxflow.stereotyped.step.data.KindPrefixBuilder.Companion.build
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class KindPrefixBuilderTest {
+    data class ExampleData(
+        @Data val plainAnnotated: String,
+        @Data(identifier = "customId") val customAnnotated: Int,
+        val withoutAnnotation: Boolean,
+        @Data(identifier = "") val blankIdentifierAnnotated: Long,
+    )
+
+    @Test
+    fun `apply should return original name when prefix is empty regardless of strategy`() {
+        // Arrange
+        val builderPlain = KindPrefixBuilder(PrefixStrategy.Plain, "")
+        val builderCamel = KindPrefixBuilder(PrefixStrategy.CamelCase, "")
+
+        // Act / Assert
+        assertThat(builderPlain.apply("value")).isEqualTo("value")
+        assertThat(builderCamel.apply("value")).isEqualTo("value")
+    }
+
+    @Test
+    fun `apply should concatenate prefix and name with Plain strategy`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.Plain, "foo")
+        assertThat(builder.apply("bar")).isEqualTo("foobar")
+    }
+
+    @Test
+    fun `apply should camelCase first letter of name with CamelCase strategy for multi char name`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.CamelCase, "pre")
+        assertThat(builder.apply("value")).isEqualTo("preValue")
+    }
+
+    @Test
+    fun `apply should uppercase single letter for CamelCase strategy`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.CamelCase, "x")
+        assertThat(builder.apply("a")).isEqualTo("xA")
+    }
+
+    @Test
+    fun `and should create new builder when receiver is null`() {
+        // Arrange
+        val import = Import(prefix = "foo", prefixStrategy = PrefixStrategy.Plain)
+
+        // Act
+        val result = (null as KindPrefixBuilder?).and(import)
+
+        // Assert
+        assertThat(result).isNotNull()
+        assertThat(result!!.prefix).isEqualTo("foo")
+        assertThat(result.strategy).isEqualTo(PrefixStrategy.Plain)
+    }
+
+    @Test
+    fun `and should chain prefixes using previous strategy`() {
+        // Arrange
+        val first = KindPrefixBuilder(PrefixStrategy.CamelCase, "foo")
+        val secondImport = Import(prefix = "bar", prefixStrategy = PrefixStrategy.Plain)
+
+        // Act
+        val chained = first.and(secondImport)!!
+
+        // Assert
+        // Previous strategy CamelCase turns "bar" into "Bar" -> prefix becomes fooBar
+        assertThat(chained.prefix).isEqualTo("fooBar")
+        // Strategy is replaced by the new annotation's strategy
+        assertThat(chained.strategy).isEqualTo(PrefixStrategy.Plain)
+    }
+
+    @Test
+    fun `and should allow multiple chaining with different strategies`() {
+        // Arrange
+        val import1 = Import(prefix = "alpha", prefixStrategy = PrefixStrategy.Plain)
+        val import2 = Import(prefix = "beta", prefixStrategy = PrefixStrategy.CamelCase)
+        val import3 = Import(prefix = "gamma", prefixStrategy = PrefixStrategy.Plain)
+
+        // Act
+        val after1 = (null as KindPrefixBuilder?).and(import1)!! // prefix alpha, strategy Plain
+        val after2 = after1.and(import2)!! // prefix alphabeta, strategy CamelCase
+        val after3 = after2.and(import3)!! // prefix alphabetaGamma, strategy Plain
+
+        // Assert
+        assertThat(after3.prefix).isEqualTo("alphabetaGamma")
+        assertThat(after3.strategy).isEqualTo(PrefixStrategy.Plain)
+    }
+
+    @Test
+    fun `build should return raw kind (property name) when builder is null and no Data identifier`() {
+        val kind = (null as KindPrefixBuilder?).build(ExampleData::withoutAnnotation)
+        assertThat(kind).isEqualTo(DataKind("withoutAnnotation"))
+    }
+
+    @Test
+    fun `build should use @Data identifier when present`() {
+        val kind = (null as KindPrefixBuilder?).build(ExampleData::customAnnotated)
+        assertThat(kind).isEqualTo(DataKind("customId"))
+    }
+
+    @Test
+    fun `build should fall back to property name when @Data identifier blank`() {
+        val kind = (null as KindPrefixBuilder?).build(ExampleData::blankIdentifierAnnotated)
+        assertThat(kind).isEqualTo(DataKind("blankIdentifierAnnotated"))
+    }
+
+    @Test
+    fun `build should prefix raw kind when builder provided with Plain strategy`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.Plain, "pre")
+        val kind = builder.build(ExampleData::withoutAnnotation)
+        assertThat(kind).isEqualTo(DataKind("prewithoutAnnotation"))
+    }
+
+    @Test
+    fun `build should prefix and camelCase raw kind when builder provided with CamelCase strategy`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.CamelCase, "pre")
+        val kind = builder.build(ExampleData::withoutAnnotation)
+        assertThat(kind).isEqualTo(DataKind("preWithoutAnnotation"))
+    }
+
+    @Test
+    fun `build should not alter kind when builder prefix is empty`() {
+        val builder = KindPrefixBuilder(PrefixStrategy.CamelCase, "")
+        val kind = builder.build(ExampleData::withoutAnnotation)
+        assertThat(kind).isEqualTo(DataKind("withoutAnnotation"))
+    }
+
+    @Test
+    fun `build should apply combined chained prefix to raw kind`() {
+        // Arrange
+        val import1 = Import(prefix = "foo", prefixStrategy = PrefixStrategy.Plain)
+        val import2 = Import(prefix = "bar", prefixStrategy = PrefixStrategy.CamelCase)
+        val chained = (null as KindPrefixBuilder?).and(import1)?.and(import2)!!
+
+        // Act
+        val kind = chained.build(ExampleData::withoutAnnotation)
+
+        // Assert
+        // After chaining: first prefix = foo; then CamelCase prefix for second takes Plain.apply(foo, bar) => foobar, so chained.prefix = foobar, strategy CamelCase
+        assertThat(chained.prefix).isEqualTo("foobar")
+        assertThat(kind).isEqualTo(DataKind("foobarWithoutAnnotation"))
+    }
+}


### PR DESCRIPTION
This PR provides initial features to support importing/spreading data objects using the `@Import`.

Features like validation and documentation will be added in a future PR.

Relates to #145.