### PR TITLE
Add FlowQuery ifPresent helper for optional filters

### DIFF
--- a/docs/features/queries.md
+++ b/docs/features/queries.md
@@ -48,7 +48,7 @@ grouped into the following categories:
 ### Conditional Filtering
 
 When filters depend on optional input values,
-you can use `whenPresent` to conditionally append a predicate.
+you can use `ifPresent` to conditionally append a predicate.
 
 A value is considered absent when it is:
 - `null`
@@ -64,12 +64,12 @@ data class WorkflowSearchRequest(
 )
 
 val query = FlowQuery.of<WorkflowQueryable>()
-    .whenPresent(request.city) { city ->
+    .ifPresent(request.city) { city ->
         get(WorkflowQueryable::model)
             .get(PizzaOrder::city)
             .isEqual(city)
     }
-    .whenPresent(request.statuses) { statuses ->
+    .ifPresent(request.statuses) { statuses ->
         get(WorkflowQueryable::status)
             .isAnyOf(statuses)
     }

--- a/docs/features/queries.md
+++ b/docs/features/queries.md
@@ -45,6 +45,38 @@ val query = FlowQuery.of<WorkflowQueryable>()
 The FlowQuery API provides various filtering operations,
 grouped into the following categories:
 
+### Conditional Filtering
+
+When filters depend on optional input values,
+you can use `whenPresent` to conditionally append a predicate.
+
+A value is considered absent when it is:
+- `null`
+- a blank `CharSequence`
+- an empty `Collection`
+- an empty `Map`
+- an empty `Array`
+
+```kotlin
+data class WorkflowSearchRequest(
+    val city: String?,
+    val statuses: List<String>?,
+)
+
+val query = FlowQuery.of<WorkflowQueryable>()
+    .whenPresent(request.city) { city ->
+        get(WorkflowQueryable::model)
+            .get(PizzaOrder::city)
+            .isEqual(city)
+    }
+    .whenPresent(request.statuses) { statuses ->
+        get(WorkflowQueryable::status)
+            .isAnyOf(statuses)
+    }
+```
+
+This keeps query building fluent and avoids manual `if` branches around each optional filter.
+
 | Category                            | Operations                                                   |
 |-------------------------------------|--------------------------------------------------------------|
 | [Logical](#logical-operators)       | `allTrue`, `anyTrue`, `and`, `or`, `not`                     |

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/query/FlowQuery.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/query/FlowQuery.kt
@@ -222,7 +222,7 @@ interface FlowQuery<TRoot, TResult> {
     }
 
     /**
-     * Adds a filter only when [value] is considered present.
+     * Adds a filter only if [value] is considered present.
      *
      * A value is considered absent if it is:
      * - `null`
@@ -236,7 +236,7 @@ interface FlowQuery<TRoot, TResult> {
      * val cityFilter: String? = request.city
      *
      * val query = FlowQuery.of<WorkflowQueryable>()
-     *     .whenPresent(cityFilter) { city ->
+     *     .ifPresent(cityFilter) { city ->
      *         get(WorkflowQueryable::model)
      *             .get(PizzaOrder::city)
      *             .isEqual(city)
@@ -247,7 +247,7 @@ interface FlowQuery<TRoot, TResult> {
      * @param builder builds the predicate using the present, non-null [value]
      * @return the unchanged query if [value] is absent; otherwise a new query with the added filter
      */
-    fun <TValue> whenPresent(
+    fun <TValue> ifPresent(
         value: TValue?,
         builder: Expression<TRoot, TResult>.(TValue) -> Expression<TRoot, Boolean>,
     ): FlowQuery<TRoot, TResult> {

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/query/FlowQuery.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/query/FlowQuery.kt
@@ -222,6 +222,54 @@ interface FlowQuery<TRoot, TResult> {
     }
 
     /**
+     * Adds a filter only when [value] is considered present.
+     *
+     * A value is considered absent if it is:
+     * - `null`
+     * - a blank [CharSequence]
+     * - an empty [Collection]
+     * - an empty [Map]
+     * - an empty [Array]
+     *
+     * Example:
+     * ```
+     * val cityFilter: String? = request.city
+     *
+     * val query = FlowQuery.of<WorkflowQueryable>()
+     *     .whenPresent(cityFilter) { city ->
+     *         get(WorkflowQueryable::model)
+     *             .get(PizzaOrder::city)
+     *             .isEqual(city)
+     *     }
+     * ```
+     *
+     * @param value the optional value that controls whether the filter is added
+     * @param builder builds the predicate using the present, non-null [value]
+     * @return the unchanged query if [value] is absent; otherwise a new query with the added filter
+     */
+    fun <TValue> whenPresent(
+        value: TValue?,
+        builder: Expression<TRoot, TResult>.(TValue) -> Expression<TRoot, Boolean>,
+    ): FlowQuery<TRoot, TResult> {
+        val presentValue = value ?: return this
+        val isAbsent = when (presentValue) {
+            is CharSequence -> presentValue.isBlank()
+            is Collection<*> -> presentValue.isEmpty()
+            is Map<*, *> -> presentValue.isEmpty()
+            is Array<*> -> presentValue.isEmpty()
+            else -> false
+        }
+
+        if (isAbsent) {
+            return this
+        }
+
+        return where {
+            builder(presentValue)
+        }
+    }
+
+    /**
      * Appends another query's operations to this one, preserving the current root and result type.
      *
      * Example:

--- a/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/query/FlowQueryIfPresentTest.kt
+++ b/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/query/FlowQueryIfPresentTest.kt
@@ -3,15 +3,15 @@ package de.fluxflow.flowquery.query
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class FlowQueryWhenPresentTest {
+class FlowQueryIfPresentTest {
 
     @Test
-    fun `whenPresent should not change query for null values`() {
+    fun `ifPresent should not change query for null values`() {
         // Arrange
         val query = FlowQuery.of<TestModel>()
 
         // Act
-        val result = query.whenPresent(null as String?) { value ->
+        val result = query.ifPresent(null as String?) { value ->
             get(TestModel::name).isEqual(value)
         }
 
@@ -21,12 +21,12 @@ class FlowQueryWhenPresentTest {
     }
 
     @Test
-    fun `whenPresent should not change query for blank strings`() {
+    fun `ifPresent should not change query for blank strings`() {
         // Arrange
         val query = FlowQuery.of<TestModel>()
 
         // Act
-        val result = query.whenPresent("   ") { value ->
+        val result = query.ifPresent("   ") { value ->
             get(TestModel::name).isEqual(value)
         }
 
@@ -36,18 +36,18 @@ class FlowQueryWhenPresentTest {
     }
 
     @Test
-    fun `whenPresent should not change query for empty collections, maps and arrays`() {
+    fun `ifPresent should not change query for empty collections, maps and arrays`() {
         // Arrange
         val query = FlowQuery.of<TestModel>()
 
         // Act
-        val collectionResult = query.whenPresent(emptyList<String>()) { value ->
+        val collectionResult = query.ifPresent(emptyList<String>()) { value ->
             get(TestModel::tags).isAnyOf(value)
         }
-        val mapResult = query.whenPresent(emptyMap<String, String>()) { value ->
+        val mapResult = query.ifPresent(emptyMap<String, String>()) { value ->
             get(TestModel::metadata).isEqual(value)
         }
-        val arrayResult = query.whenPresent(emptyArray<String>()) { value ->
+        val arrayResult = query.ifPresent(emptyArray<String>()) { value ->
             get(TestModel::aliases).isEqual(value.toList())
         }
 
@@ -59,12 +59,12 @@ class FlowQueryWhenPresentTest {
     }
 
     @Test
-    fun `whenPresent should add a filter for present values`() {
+    fun `ifPresent should add a filter for present values`() {
         // Arrange
         val query = FlowQuery.of<TestModel>()
 
         // Act
-        val result = query.whenPresent("Cologne") { value ->
+        val result = query.ifPresent("Cologne") { value ->
             get(TestModel::name).isEqual(value)
         }
 
@@ -75,13 +75,13 @@ class FlowQueryWhenPresentTest {
     }
 
     @Test
-    fun `whenPresent should pass non-null value to builder`() {
+    fun `ifPresent should pass non-null value to builder`() {
         // Arrange
         val query = FlowQuery.of<TestModel>()
         var received: String? = null
 
         // Act
-        query.whenPresent("ACTIVE") { value ->
+        query.ifPresent("ACTIVE") { value ->
             received = value
             get(TestModel::name).isEqual(value)
         }

--- a/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/query/FlowQueryWhenPresentTest.kt
+++ b/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/query/FlowQueryWhenPresentTest.kt
@@ -1,0 +1,99 @@
+package de.fluxflow.flowquery.query
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FlowQueryWhenPresentTest {
+
+    @Test
+    fun `whenPresent should not change query for null values`() {
+        // Arrange
+        val query = FlowQuery.of<TestModel>()
+
+        // Act
+        val result = query.whenPresent(null as String?) { value ->
+            get(TestModel::name).isEqual(value)
+        }
+
+        // Assert
+        assertThat(result).isSameAs(query)
+        assertThat(result.operations).isEmpty()
+    }
+
+    @Test
+    fun `whenPresent should not change query for blank strings`() {
+        // Arrange
+        val query = FlowQuery.of<TestModel>()
+
+        // Act
+        val result = query.whenPresent("   ") { value ->
+            get(TestModel::name).isEqual(value)
+        }
+
+        // Assert
+        assertThat(result).isSameAs(query)
+        assertThat(result.operations).isEmpty()
+    }
+
+    @Test
+    fun `whenPresent should not change query for empty collections, maps and arrays`() {
+        // Arrange
+        val query = FlowQuery.of<TestModel>()
+
+        // Act
+        val collectionResult = query.whenPresent(emptyList<String>()) { value ->
+            get(TestModel::tags).isAnyOf(value)
+        }
+        val mapResult = query.whenPresent(emptyMap<String, String>()) { value ->
+            get(TestModel::metadata).isEqual(value)
+        }
+        val arrayResult = query.whenPresent(emptyArray<String>()) { value ->
+            get(TestModel::aliases).isEqual(value.toList())
+        }
+
+        // Assert
+        assertThat(collectionResult).isSameAs(query)
+        assertThat(mapResult).isSameAs(query)
+        assertThat(arrayResult).isSameAs(query)
+        assertThat(query.operations).isEmpty()
+    }
+
+    @Test
+    fun `whenPresent should add a filter for present values`() {
+        // Arrange
+        val query = FlowQuery.of<TestModel>()
+
+        // Act
+        val result = query.whenPresent("Cologne") { value ->
+            get(TestModel::name).isEqual(value)
+        }
+
+        // Assert
+        assertThat(result).isNotSameAs(query)
+        assertThat(result.operations).hasSize(1)
+        assertThat(result.operations.first()).isInstanceOf(FilterOperation::class.java)
+    }
+
+    @Test
+    fun `whenPresent should pass non-null value to builder`() {
+        // Arrange
+        val query = FlowQuery.of<TestModel>()
+        var received: String? = null
+
+        // Act
+        query.whenPresent("ACTIVE") { value ->
+            received = value
+            get(TestModel::name).isEqual(value)
+        }
+
+        // Assert
+        assertThat(received).isEqualTo("ACTIVE")
+    }
+
+    data class TestModel(
+        val name: String,
+        val tags: List<String>,
+        val metadata: Map<String, String>,
+        val aliases: List<String>,
+    )
+}


### PR DESCRIPTION
Introduce a FlowQuery utility that conditionally applies where predicates for present values, so developers can build optional query filters more fluently