### PR TITLE
Improve FlowQuery isType performance with subtype caching

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -36,7 +36,7 @@ subprojects {
     apply(plugin = "org.jetbrains.dokka")
 
     group = "de.lise.fluxflow"
-    version = projVersion ?: "0.3.0-SNAPSHOT-5"
+    version = projVersion ?: "0.3.0-SNAPSHOT-6"
     
     repositories {
         mavenCentral()

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/SubclassProviderImpl.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/SubclassProviderImpl.kt
@@ -3,12 +3,19 @@ package de.lise.fluxflow.mongo.flowquery.expression.compilation
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.type.filter.AssignableTypeFilter
 import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 class SubclassProviderImpl(
     private val basePackages: Set<String>
 ) : SubclassProvider {
+    private val cache = ConcurrentHashMap<KClass<*>, Set<Class<*>>>()
+
     override fun findSubclasses(type: KClass<*>): Set<Class<*>> {
+        return cache.computeIfAbsent(type) { findSubclassesUncached(it) }
+    }
+
+    private fun findSubclassesUncached(type: KClass<*>): Set<Class<*>> {
         val scanner = ClassPathScanningCandidateComponentProvider(false)
         scanner.addIncludeFilter(AssignableTypeFilter(type.java))
 


### PR DESCRIPTION
Cache subclass discovery results per requested type to avoid repeated classpath scans during Mongo FlowQuery compilation