### PR TITLE
Fix type-guarded asType sorting in FlowQuery

### DIFF
--- a/docs/features/queries.md
+++ b/docs/features/queries.md
@@ -102,6 +102,11 @@ val query = FlowQuery.of<WorkflowQueryable>()
     }
 ```
 
+When sorting on a property of a workflow model subtype, use `asType` to narrow the model first.
+Workflows whose model does not match the cast type (or a known subtype) keep their place in the
+result set and receive a `null` sort key. Null placement follows the backend defaults
+(nulls-first on ascending, nulls-last on descending). Filter semantics for `asType` are unchanged.
+
 ### Pagination
 
 To retrieve paginated results,

--- a/library/core/flowquery/build.gradle.kts
+++ b/library/core/flowquery/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     api(project(":core:query"))
     implementation(kotlin("reflect"))
+    implementation("org.springframework:spring-context")
 }

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/ClasspathSubclassProvider.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/ClasspathSubclassProvider.kt
@@ -1,4 +1,4 @@
-package de.lise.fluxflow.mongo.flowquery.expression.compilation
+package de.fluxflow.flowquery.expression.compilation
 
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.core.type.filter.AssignableTypeFilter
@@ -6,8 +6,11 @@ import java.lang.reflect.Modifier
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
-class SubclassProviderImpl(
-    private val basePackages: Set<String>
+/**
+ * Discovers concrete subtypes of a [KClass] by scanning configured base packages.
+ */
+class ClasspathSubclassProvider(
+    private val basePackages: Set<String>,
 ) : SubclassProvider {
     private val cache = ConcurrentHashMap<KClass<*>, Set<Class<*>>>()
 
@@ -23,7 +26,7 @@ class SubclassProviderImpl(
             .filter { !it.isAbstract }
             .mapNotNull { it.beanClassName }
             .distinct()
-            .mapNotNull { Class.forName(it) }
+            .mapNotNull { runCatching { Class.forName(it) }.getOrNull() }
 
         val allClasses = (allFoundClasses + type.java).toSet()
         return allClasses.filter {

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/StaticSubclassProvider.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/StaticSubclassProvider.kt
@@ -1,0 +1,14 @@
+package de.fluxflow.flowquery.expression.compilation
+
+import kotlin.reflect.KClass
+
+/**
+ * [SubclassProvider] with an explicit registry, primarily for unit tests.
+ */
+class StaticSubclassProvider(
+    private val subclassesByType: Map<KClass<*>, Set<Class<*>>> = emptyMap(),
+) : SubclassProvider {
+    override fun findSubclasses(type: KClass<*>): Set<Class<*>> {
+        return subclassesByType[type] ?: setOf(type.java)
+    }
+}

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/SubclassProvider.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/expression/compilation/SubclassProvider.kt
@@ -1,0 +1,11 @@
+package de.fluxflow.flowquery.expression.compilation
+
+import kotlin.reflect.KClass
+
+/**
+ * Provides the set of concrete types considered subtypes of a given type.
+ * Used by [de.fluxflow.flowquery.expression.CastExpression] sorting and [de.fluxflow.flowquery.expression.IsTypeExpression] checks.
+ */
+interface SubclassProvider {
+    fun findSubclasses(type: KClass<*>): Set<Class<*>>
+}

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/inmemory/expression/compilation/InMemoryCompiler.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/inmemory/expression/compilation/InMemoryCompiler.kt
@@ -4,11 +4,15 @@ import de.fluxflow.flowquery.expression.*
 import de.fluxflow.flowquery.expression.compilation.CompilationException
 import de.fluxflow.flowquery.expression.compilation.CompilationResult
 import de.fluxflow.flowquery.expression.compilation.ExpressionCompiler
+import de.fluxflow.flowquery.expression.compilation.StaticSubclassProvider
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import de.fluxflow.flowquery.inmemory.expression.compilation.ops.*
 import de.fluxflow.flowquery.inmemory.query.sorting.InMemoryComparator
 import kotlin.reflect.KProperty1
 
-class InMemoryCompiler : ExpressionCompiler<InMemoryOp<*, *>> {
+class InMemoryCompiler(
+    private val subclassProvider: SubclassProvider = StaticSubclassProvider(),
+) : ExpressionCompiler<InMemoryOp<*, *>> {
     override fun <TRoot, TResult> compile(
         expression: Expression<TRoot, TResult>
     ): CompilationResult<InMemoryOp<TRoot, TResult>> {
@@ -195,7 +199,8 @@ class InMemoryCompiler : ExpressionCompiler<InMemoryOp<*, *>> {
                     rootExpression,
                     exp.instance
                 ) as InMemoryOp<TRoot, Any?>,
-                exp.requiredType
+                exp.requiredType,
+                subclassProvider,
             )
 
             is MapAccessExpression<TRoot, *, *, *> -> InMemoryMapAccessOp(

--- a/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/inmemory/expression/compilation/ops/CastOp.kt
+++ b/library/core/flowquery/src/main/kotlin/de/fluxflow/flowquery/inmemory/expression/compilation/ops/CastOp.kt
@@ -1,12 +1,23 @@
 package de.fluxflow.flowquery.inmemory.expression.compilation.ops
 
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import kotlin.reflect.KClass
 
-data class CastOp<TRoot, TCurrent, TTarget : Any>(
-    private val instance: InMemoryOp<TRoot, TCurrent>,
-    private val requiredType: KClass<TTarget>
+data class CastOp<TRoot, TTarget : Any>(
+    private val instance: InMemoryOp<TRoot, Any?>,
+    private val requiredType: KClass<TTarget>,
+    private val subclassProvider: SubclassProvider,
 ) : InMemoryOp<TRoot, TTarget> {
+    private val allowedTypes by lazy {
+        subclassProvider.findSubclasses(requiredType)
+    }
+
     override fun execute(input: TRoot): TTarget? {
-        return instance.execute(input) as? TTarget?
+        val value = instance.execute(input) ?: return null
+        if (allowedTypes.none { it.isInstance(value) }) {
+            return null
+        }
+        @Suppress("UNCHECKED_CAST")
+        return value as TTarget
     }
 }

--- a/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/inmemory/query/InMemoryAsTypeSortIT.kt
+++ b/library/core/flowquery/src/test/kotlin/de/fluxflow/flowquery/inmemory/query/InMemoryAsTypeSortIT.kt
@@ -1,0 +1,54 @@
+package de.fluxflow.flowquery.inmemory.query
+
+import de.fluxflow.flowquery.expression.ExpressionExtensions.Types.asType
+import de.fluxflow.flowquery.expression.compilation.StaticSubclassProvider
+import de.fluxflow.flowquery.inmemory.expression.compilation.InMemoryCompiler
+import de.fluxflow.flowquery.query.sorting.Sort.Companion.asc
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class InMemoryAsTypeSortIT {
+    @Test
+    fun `sort should use casted property for matching types and null for others`() {
+        // Arrange
+        val data = listOf(
+            TestRoot(TypedModel("B")),
+            TestRoot(OtherModel("Z")),
+            TestRoot(TypedModel("A")),
+            TestRoot(BaseModel()),
+        )
+        val repo = InMemoryQueryRepository(
+            InMemoryCompiler(
+                StaticSubclassProvider(
+                    mapOf(
+                        TypedModel::class to setOf(TypedModel::class.java),
+                    )
+                )
+            )
+        ) { data }
+
+        // Act
+        val result = repo.find {
+            sort {
+                get(TestRoot::model)
+                    .asType(TypedModel::class)
+                    .get(TypedModel::label)
+                    .asc()
+            }
+        }
+
+        // Assert
+        assertThat(result.items).hasSize(4)
+
+        val labels = result.items.map { (it.model as? TypedModel)?.label }
+        assertThat(labels).containsExactly(null, null, "A", "B")
+    }
+
+    private open class BaseModel
+
+    private class TypedModel(val label: String) : BaseModel()
+
+    private class OtherModel(val label: String) : BaseModel()
+
+    private data class TestRoot(val model: BaseModel)
+}

--- a/library/springboot/springboot-in-memory-persistence/build.gradle.kts
+++ b/library/springboot/springboot-in-memory-persistence/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     api(project(":core:test-persistence"))
     implementation("org.springframework:spring-context")
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
 }

--- a/library/springboot/springboot-in-memory-persistence/src/main/kotlin/de/lise/fluxflow/springboot/InMemoryPersistenceConfiguration.kt
+++ b/library/springboot/springboot-in-memory-persistence/src/main/kotlin/de/lise/fluxflow/springboot/InMemoryPersistenceConfiguration.kt
@@ -1,6 +1,11 @@
 package de.lise.fluxflow.springboot
 
+import de.fluxflow.flowquery.expression.compilation.ClasspathSubclassProvider
+import de.fluxflow.flowquery.expression.compilation.StaticSubclassProvider
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import de.fluxflow.flowquery.inmemory.expression.compilation.InMemoryCompiler
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages
 import de.lise.fluxflow.migration.MigrationProvider
 import de.lise.fluxflow.persistence.continuation.history.ContinuationRecordPersistence
 import de.lise.fluxflow.persistence.job.JobPersistence
@@ -27,8 +32,19 @@ open class InMemoryPersistenceConfiguration {
     }
 
     @Bean
-    open fun inMemoryCompiler(): InMemoryCompiler {
-        return InMemoryCompiler()
+    open fun subclassProvider(factory: BeanFactory): SubclassProvider {
+        val basePackages = runCatching { AutoConfigurationPackages.get(factory).toSet() }
+            .getOrElse { emptySet() }
+        return if (basePackages.isEmpty()) {
+            StaticSubclassProvider()
+        } else {
+            ClasspathSubclassProvider(basePackages)
+        }
+    }
+
+    @Bean
+    open fun inMemoryCompiler(subclassProvider: SubclassProvider): InMemoryCompiler {
+        return InMemoryCompiler(subclassProvider)
     }
 
     @Bean

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/MongoConfiguration.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/MongoConfiguration.kt
@@ -2,9 +2,9 @@ package de.lise.fluxflow.mongo
 
 import de.lise.fluxflow.mongo.bootstrapping.BootstrapMongoConfiguration
 import de.lise.fluxflow.mongo.continuation.history.ContinuationMongoConfiguration
+import de.fluxflow.flowquery.expression.compilation.ClasspathSubclassProvider
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.MongoCompiler
-import de.lise.fluxflow.mongo.flowquery.expression.compilation.SubclassProvider
-import de.lise.fluxflow.mongo.flowquery.expression.compilation.SubclassProviderImpl
 import de.lise.fluxflow.mongo.flowquery.repository.MongoQueryTranslator
 import de.lise.fluxflow.mongo.job.JobMongoConfiguration
 import de.lise.fluxflow.mongo.migration.MigrationMongoConfiguration
@@ -33,7 +33,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 open class MongoConfiguration {
     @Bean
     open fun subclassProvider(factory: BeanFactory): SubclassProvider {
-        return SubclassProviderImpl(AutoConfigurationPackages.get(factory).toSet())
+        return ClasspathSubclassProvider(AutoConfigurationPackages.get(factory).toSet())
     }
 
     @Bean

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/MongoCompiler.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/MongoCompiler.kt
@@ -4,11 +4,13 @@ import de.fluxflow.flowquery.expression.*
 import de.fluxflow.flowquery.expression.compilation.CompilationException
 import de.fluxflow.flowquery.expression.compilation.CompilationResult
 import de.fluxflow.flowquery.expression.compilation.ExpressionCompiler
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.mapping.MongoCompilerMapper
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.mapping.MongoCompilerMapperImpl
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.*
 import org.bson.Document
 import org.slf4j.LoggerFactory
+import kotlin.reflect.KProperty
 
 internal class MongoCompiler(
     private val subclassProvider: SubclassProvider,
@@ -33,6 +35,85 @@ internal class MongoCompiler(
             logger.error("Failed to compile expression: {}", mappedExpression, e)
             throw CompilationException(mappedExpression, mappedExpression, "Compilation failed: ${e.message}")
         }
+    }
+
+    fun <TRoot, TResult> compileForSort(
+        expression: Expression<TRoot, TResult>,
+        sortFieldIndex: Int,
+    ): CompilationResult<MongoSortToken> {
+        val mappedExpression = expressionMapper.map(expression)
+
+        return try {
+            val result = compileSortExpression(mappedExpression, mappedExpression, sortFieldIndex)
+            if (logger.isTraceEnabled) {
+                logger.trace("Successfully compiled sort expression {} to MongoDB sort token: {}", mappedExpression, result)
+            }
+
+            CompilationResult(result)
+        } catch (e: Exception) {
+            logger.error("Failed to compile sort expression: {}", mappedExpression, e)
+            throw CompilationException(mappedExpression, mappedExpression, "Sort compilation failed: ${e.message}")
+        }
+    }
+
+    private fun <TRoot, TResult> compileSortExpression(
+        root: Expression<TRoot, *>,
+        expression: Expression<TRoot, TResult>,
+        sortFieldIndex: Int,
+    ): MongoSortToken {
+        if (expression is PropertyExpression<TRoot, *, *> &&
+            expression.instance is CastExpression<TRoot, *, *>
+        ) {
+            @Suppress("UNCHECKED_CAST")
+            return typeGuardedPropertySort(
+                root,
+                expression.instance as CastExpression<TRoot, *, *>,
+                expression.property,
+                sortFieldIndex,
+            )
+        }
+
+        return PathSortToken(
+            doCompile(root, expression).asStatementToken(root, expression)
+        )
+    }
+
+    private fun <TRoot> typeGuardedPropertySort(
+        root: Expression<TRoot, *>,
+        cast: CastExpression<TRoot, *, *>,
+        property: KProperty<*>,
+        sortFieldIndex: Int,
+    ): ComputedSortToken {
+        val instanceToken = doCompile(root, cast.instance).asStatementToken(root, cast.instance)
+        val typeFieldPath = ConvertingStatementToken(instanceToken) { "${it}.${config.typeFieldName}" }
+        val allowedTypes = subclassProvider.findSubclasses(cast.requiredType).map { it.name }
+        val propertyPath = PropertyToken(instanceToken, property).toStatement()
+
+        val expression = Document(
+            "\$cond",
+            Document()
+                .append(
+                    "if",
+                    Document(
+                        "\$in",
+                        listOf(
+                            toFieldReference(typeFieldPath.toStatement()),
+                            allowedTypes,
+                        )
+                    )
+                )
+                .append("then", toFieldReference(propertyPath))
+                .append("else", null)
+        )
+
+        return ComputedSortToken(
+            fieldName = "__flowquery_sort_$sortFieldIndex",
+            expression = expression,
+        )
+    }
+
+    private fun toFieldReference(path: String): String {
+        return "$$path"
     }
 
     private fun <TRoot, TCurrent> doCompile(

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/SubclassProvider.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/SubclassProvider.kt
@@ -1,7 +1,0 @@
-package de.lise.fluxflow.mongo.flowquery.expression.compilation
-
-import kotlin.reflect.KClass
-
-interface SubclassProvider {
-    fun findSubclasses(type: KClass<*>): Set<Class<*>>
-}

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/ComputedSortToken.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/ComputedSortToken.kt
@@ -1,0 +1,11 @@
+package de.lise.fluxflow.mongo.flowquery.expression.compilation.token
+
+import org.bson.Document
+
+/**
+ * Sort by a computed aggregation expression, materialized via `$addFields` before `$sort`.
+ */
+internal data class ComputedSortToken(
+    val fieldName: String,
+    val expression: Document,
+) : MongoSortToken

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/MongoSortToken.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/MongoSortToken.kt
@@ -1,0 +1,6 @@
+package de.lise.fluxflow.mongo.flowquery.expression.compilation.token
+
+/**
+ * Result of compiling a sort expression for MongoDB aggregation.
+ */
+internal sealed interface MongoSortToken

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/PathSortToken.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/token/PathSortToken.kt
@@ -1,0 +1,8 @@
+package de.lise.fluxflow.mongo.flowquery.expression.compilation.token
+
+/**
+ * Sort by an existing document field path.
+ */
+internal data class PathSortToken(
+    val path: StatementToken,
+) : MongoSortToken

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslator.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslator.kt
@@ -102,28 +102,41 @@ internal class MongoQueryTranslator(private val compiler: MongoCompiler) {
      * Translates a [SortingOperation] into a Mongo `$sort` stage.
      */
     private fun toSorting(operation: SortingOperation): List<AggregationOperation> {
-        val sortSpec = operation.sorting.sorts.associate { sort ->
-            val token = compiler.compile(sort.expression).result
-            val sortKey = toSortKey(operation, token)
-            sortKey.toStatement() to when (sort.direction) {
-                SortDirection.Ascending -> 1
-                SortDirection.Descending -> -1
+        val addFields = Document()
+        val sortSpec = Document()
+
+        operation.sorting.sorts.forEachIndexed { index, sort ->
+            when (val token = compiler.compileForSort(sort.expression, index).result) {
+                is PathSortToken -> {
+                    sortSpec[token.path.toStatement()] = when (sort.direction) {
+                        SortDirection.Ascending -> 1
+                        SortDirection.Descending -> -1
+                    }
+                }
+
+                is ComputedSortToken -> {
+                    addFields[token.fieldName] = token.expression
+                    sortSpec[token.fieldName] = when (sort.direction) {
+                        SortDirection.Ascending -> 1
+                        SortDirection.Descending -> -1
+                    }
+                }
             }
         }
 
-        return listOf(
-            Aggregation.stage(
-                Document(mapOf("\$sort" to Document(sortSpec)))
-            )
-        )
-    }
-
-    private fun toSortKey(operation: SortingOperation, token: MongoToken): StatementToken {
-        return when (token) {
-            is StatementToken -> token
-            else -> throw QueryExecutionException(
-                "Cannot sort by '${operation.toText()}': expected statement, got ${token::class.simpleName}"
+        val stages = mutableListOf<AggregationOperation>()
+        if (!addFields.isEmpty()) {
+            stages.add(
+                Aggregation.stage(
+                    Document(mapOf("\$addFields" to addFields))
+                )
             )
         }
+        stages.add(
+            Aggregation.stage(
+                Document(mapOf("\$sort" to sortSpec))
+            )
+        )
+        return stages
     }
 }

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/MongoCompilerTest.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/expression/compilation/MongoCompilerTest.kt
@@ -7,6 +7,7 @@ import de.fluxflow.flowquery.expression.ExpressionExtensions.Logical.or
 import de.fluxflow.flowquery.expression.ExpressionExtensions.Strings.endsWith
 import de.fluxflow.flowquery.expression.ExpressionExtensions.Strings.startsWith
 import de.fluxflow.flowquery.expression.compilation.CompilationException
+import de.fluxflow.flowquery.expression.compilation.SubclassProvider
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.mapping.MongoCompilerMapper
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.*
 import org.assertj.core.api.Assertions.assertThat
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
 import kotlin.reflect.KClass
+import de.fluxflow.flowquery.expression.ExpressionExtensions.Types.asType
 import de.fluxflow.flowquery.expression.ExpressionExtensions.Strings.contains as stringContains
 
 class MongoCompilerTest {
@@ -117,6 +119,27 @@ class MongoCompilerTest {
         // Assert
         assertThat(result.result).isInstanceOf(StatementOperationToken::class.java)
         verify(mockSubclassProvider).findSubclasses(mockClass)
+    }
+
+    @Test
+    fun `compileForSort should type-guard casted property access`() {
+        // Arrange
+        val root = Expression.root<TestUser>()
+        val sortExpression = root.get(TestUser::address)
+            .asType(ShippingAddress::class)
+            .get(ShippingAddress::city)
+
+        whenever(mockSubclassProvider.findSubclasses(ShippingAddress::class))
+            .thenReturn(setOf(ShippingAddress::class.java))
+
+        // Act
+        val result = compiler.compileForSort(sortExpression, 0)
+
+        // Assert
+        assertThat(result.result).isInstanceOf(ComputedSortToken::class.java)
+        val computed = result.result as ComputedSortToken
+        assertThat(computed.fieldName).isEqualTo("__flowquery_sort_0")
+        assertThat(computed.expression).containsKey("\$cond")
     }
 
     @Test
@@ -585,6 +608,11 @@ class MongoCompilerTest {
         val isActive: Boolean,
         val isAdmin: Boolean,
         val roles: List<String>,
-        val metadata: Map<String, String>
+        val metadata: Map<String, String>,
+        val address: Any = GenericAddress(),
     )
+
+    open class GenericAddress
+
+    class ShippingAddress(val city: String) : GenericAddress()
 }

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryRepositoryIT.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryRepositoryIT.kt
@@ -378,6 +378,62 @@ class MongoQueryRepositoryIT {
     }
 
     @Test
+    fun `find should sort by casted property and keep non-matching documents`() {
+        // Arrange
+        template.insert(
+            TestDocument(
+                id = UUID.randomUUID().toString(),
+                someStringProp = "typed-low",
+                anotherStringProp = "typed-low",
+                longStringProperty = "typed-low",
+                aBooleanProperty = true,
+                anAnyProperty = NestedTestDocument(anIntProperty = 1),
+                nestedProperty = NestedTestDocument(anIntProperty = 0),
+            )
+        )
+        template.insert(
+            TestDocument(
+                id = UUID.randomUUID().toString(),
+                someStringProp = "typed-high",
+                anotherStringProp = "typed-high",
+                longStringProperty = "typed-high",
+                aBooleanProperty = true,
+                anAnyProperty = NestedTestDocument(anIntProperty = 9),
+                nestedProperty = NestedTestDocument(anIntProperty = 0),
+            )
+        )
+        template.insert(
+            TestDocument(
+                id = UUID.randomUUID().toString(),
+                someStringProp = "wrong-type",
+                anotherStringProp = "wrong-type",
+                longStringProperty = "wrong-type",
+                aBooleanProperty = true,
+                anAnyProperty = OtherPropertyHolder(anIntProperty = 100),
+                nestedProperty = NestedTestDocument(anIntProperty = 0),
+            )
+        )
+
+        // Act
+        val result = repo.find {
+            sort {
+                get(TestDocument::anAnyProperty)
+                    .asType(NestedTestDocument::class)
+                    .get(NestedTestDocument::anIntProperty)
+                    .asc()
+            }
+        }.items
+
+        // Assert
+        assertThat(result).hasSize(testDocuments.size + 3)
+        assertThat(
+            result.map { document ->
+                (document.anAnyProperty as? NestedTestDocument)?.anIntProperty
+            }
+        ).containsExactly(null, null, null, 1, 3, 9)
+    }
+
+    @Test
     fun `find should support casted property filters`() {
         val result = repo.findSingle {
             where {
@@ -535,6 +591,10 @@ class MongoQueryRepositoryIT {
         val someInstant: Instant? = null,
         val id: String? = null,
     ) : NestedDocument
+
+    data class OtherPropertyHolder(
+        val anIntProperty: Int,
+    )
 
     internal interface NestedDocument
 }

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslatorTest.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslatorTest.kt
@@ -10,6 +10,7 @@ import de.fluxflow.flowquery.query.sorting.Sorting
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.MongoCompiler
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.ConstantToken
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.ExpressionToken
+import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.PathSortToken
 import de.lise.fluxflow.mongo.flowquery.expression.compilation.token.StatementToken
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -115,7 +116,7 @@ class MongoQueryTranslatorTest {
         val statementToken = mock<StatementToken> {
             on { toStatement() }.thenReturn("user.age")
         }
-        whenever(compiler.compile(expression)).thenReturn(CompilationResult(statementToken))
+        whenever(compiler.compileForSort(expression, 0)).thenReturn(CompilationResult(PathSortToken(statementToken)))
 
         val query = mock<FlowQuery<Any, Any>>()
         whenever(query.operations).thenReturn(listOf(sortingOperation))
@@ -194,14 +195,16 @@ class MongoQueryTranslatorTest {
         val sort = Sort(expression, SortDirection.Ascending)
         val operation = SortingOperation(Sorting(listOf(sort)))
 
-        whenever(compiler.compile(expression)).thenReturn(CompilationResult(ConstantToken("oops")))
+        whenever(compiler.compileForSort(expression, 0)).thenThrow(
+            RuntimeException("Sort compilation failed")
+        )
 
         val query = mock<FlowQuery<Any, Any>>()
         whenever(query.operations).thenReturn(listOf(operation))
 
         // Act & Assert
         assertThatThrownBy { translator.translate(query) }
-            .isInstanceOf(QueryExecutionException::class.java)
-            .hasMessageContaining("Cannot sort by")
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("Sort compilation failed")
     }
 }

--- a/library/springboot/springboot-testing/src/main/kotlin/de/lise/fluxflow/springboot/testing/TestingConfiguration.kt
+++ b/library/springboot/springboot-testing/src/main/kotlin/de/lise/fluxflow/springboot/testing/TestingConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Import
 
 @Configuration
 @Import(
-    BasicConfiguration::class, 
-    InMemoryPersistenceConfiguration::class  
+    BasicConfiguration::class,
+    InMemoryPersistenceConfiguration::class
 )
 open class TestingConfiguration

--- a/library/springboot4/springboot-in-memory-persistence/build.gradle.kts
+++ b/library/springboot4/springboot-in-memory-persistence/build.gradle.kts
@@ -10,4 +10,5 @@ kotlin {
 dependencies {
     api(project(":core:test-persistence"))
     implementation("org.springframework:spring-context")
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
 }


### PR DESCRIPTION
* Sorting with `asType(...).get(property)` now type-guards the sort key using `SubclassProvider`, so non-matching workflow models receive a null sort key instead of being ordered by coincidentally matching fields.
* Mongo compiles casted sort expressions to a conditional `$addFields` key; in-memory `CastOp` uses the same subtype registry.

