### PR TITLE
fix: stabilize Mongo FlowQuery pagination with _id sort tiebreaker

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -21,7 +21,7 @@ val projVersion = project.findProperty("projVersion")
 
 val springBoot3Version = "3.5.7"
 val springBoot4Version = "4.0.6"
-val defaultProjectVersion = "0.3.0-SNAPSHOT-6"
+val defaultProjectVersion = "0.3.0-SNAPSHOT-7"
 val resolvedProjectVersion = projVersion ?: defaultProjectVersion
 
 val intermediateProjectPaths = setOf(":core", ":springboot", ":springboot4")

--- a/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslator.kt
+++ b/library/springboot/springboot-mongo/src/main/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslator.kt
@@ -110,6 +110,8 @@ internal class MongoQueryTranslator(private val compiler: MongoCompiler) {
                 SortDirection.Descending -> -1
             }
         }
+            .toMutableMap()
+            .also { it.putIfAbsent("_id", 1) }
 
         return listOf(
             Aggregation.stage(

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoFlowQueryRepositoryTest.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoFlowQueryRepositoryTest.kt
@@ -1,0 +1,95 @@
+package de.lise.fluxflow.mongo.flowquery.repository
+
+import de.fluxflow.flowquery.query.sorting.Sort.Companion.asc
+import de.lise.fluxflow.mongo.flowquery.expression.compilation.MongoCompiler
+import de.lise.fluxflow.mongo.flowquery.expression.compilation.SubclassProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.bson.Document
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+
+/**
+ * Unit tests for [MongoFlowQueryRepository] that do not require Docker.
+ *
+ * Integration tests in [MongoQueryRepositoryIT] are gated on a running Docker daemon
+ * via [@MongoIntegrationTest][de.lise.fluxflow.mongo.MongoIntegrationTest].
+ */
+class MongoFlowQueryRepositoryTest {
+
+    private lateinit var translator: MongoQueryTranslator
+    private lateinit var executor: MongoExecutor<WorkflowDocument>
+    private lateinit var repo: MongoFlowQueryRepository<WorkflowDocument>
+
+    @BeforeEach
+    fun setup() {
+        val subclassProvider: SubclassProvider = mock()
+        translator = MongoQueryTranslator(MongoCompiler(subclassProvider))
+        executor = mock()
+        repo = MongoFlowQueryRepository(WorkflowDocument::class.java, translator, executor)
+    }
+
+    @Test
+    fun `paged query pipeline should sort with unique tiebreaker before skip and limit`() {
+        // Arrange
+        whenever(
+            executor.executePaged(any(), any(), any(), eq(WorkflowDocument::class.java))
+        ).thenReturn(
+            PagedMongoResults(PageImpl(emptyList(), PageRequest.of(1, 5), 0))
+        )
+
+        // Act
+        repo.find {
+            sort {
+                get(WorkflowDocument::model)
+                    .get(WorkflowModel::metaInformationen)
+                    .get(MetaInformationen::bearbeitet)
+                    .get(ModificationInfo::actor)
+                    .get(User::lastName)
+                    .asc()
+            }.paged(pageIndex = 1, pageSize = 5)
+        }
+
+        // Assert
+        val pagedAggregation = argumentCaptor<Aggregation>()
+        verify(executor).executePaged(
+            pagedAggregation.capture(),
+            any(),
+            eq(PageRequest.of(1, 5)),
+            eq(WorkflowDocument::class.java),
+        )
+
+        val stages = pagedAggregation.firstValue.toPipeline(Aggregation.DEFAULT_CONTEXT)
+        val stageKeys = stages.map { it.keys.first() }
+
+        assertThat(stageKeys).containsSubsequence("\$sort", "\$skip", "\$limit")
+
+        val sortSpec = stages.single { it.containsKey("\$sort") }["\$sort"] as Document
+        assertThat(sortSpec.keys).containsExactly(
+            "model.metaInformationen.bearbeitet.actor.lastName",
+            "_id",
+        )
+        assertThat(sortSpec.getInteger("_id")).isEqualTo(1)
+
+        assertThat(stages.single { it.containsKey("\$skip") }["\$skip"]).isEqualTo(5L)
+        assertThat(stages.single { it.containsKey("\$limit") }["\$limit"]).isEqualTo(5L)
+    }
+
+    data class WorkflowDocument(val id: String, val model: WorkflowModel)
+
+    data class WorkflowModel(val metaInformationen: MetaInformationen)
+
+    data class MetaInformationen(val bearbeitet: ModificationInfo)
+
+    data class ModificationInfo(val actor: User)
+
+    data class User(val lastName: String)
+}

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslatorTest.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/flowquery/repository/MongoQueryTranslatorTest.kt
@@ -135,6 +135,36 @@ class MongoQueryTranslatorTest {
     }
 
     @Test
+    fun `sorting should append a unique _id tiebreaker to keep pagination stable`() {
+        // Arrange
+        val expression = Expression.root<Any>()
+        val sort = Sort(expression, SortDirection.Descending)
+        val sortingOperation = SortingOperation(Sorting(listOf(sort)))
+
+        val statementToken = mock<StatementToken> {
+            on { toStatement() }.thenReturn("model.metaInformationen.bearbeitet.actor.lastName")
+        }
+        whenever(compiler.compile(expression)).thenReturn(CompilationResult(statementToken))
+
+        val query = mock<FlowQuery<Any, Any>>()
+        whenever(query.operations).thenReturn(listOf(sortingOperation))
+
+        // Act
+        val aggregation = translator.translate(query)
+
+        // Assert
+        val sortSpec = stagesOf(aggregation).single()["\$sort"] as Document
+
+        // A non-unique sort key (e.g. lastName) must be disambiguated by a unique field so that
+        // $skip / $limit pagination produces a deterministic, gap-free ordering across pages.
+        assertThat(sortSpec.keys).containsExactly(
+            "model.metaInformationen.bearbeitet.actor.lastName",
+            "_id"
+        )
+        assertThat(sortSpec.getInteger("_id")).isEqualTo(1)
+    }
+
+    @Test
     fun `should translate LimitOperation into limit stage`() {
         // Arrange
         val limitOp = LimitOperation(10)


### PR DESCRIPTION
## Summary

Fixes unstable pagination when FlowQuery results are sorted and paged against MongoDB.

### Bug

When a FlowQuery uses **sort + pagination** on MongoDB, workflows can **appear on two pages** or **go missing entirely** when navigating between pages or changing sort fields. This shows up with nested property sorts (e.g. `model.metaInformationen.bearbeitet.actor.lastName`) and is especially visible when many documents share the same sort value (e.g. nulls from `asType`), but it is not limited to `asType`.

**Root cause:** `MongoFlowQueryRepository.executePaged()` runs a separate aggregation per page with `$sort` → `$skip` → `$limit`. `MongoQueryTranslator.toSorting()` built `$sort` from only the caller's sort key(s), with no unique tie-breaker. MongoDB does not guarantee a stable total order when sort keys tie, so tied documents can land in different positions across page queries — producing duplicates or gaps. The in-memory repository is unaffected because Kotlin's `sortedWith` is stable and runs once over the full list.

**Fix:** After building the user sort spec, append `_id: 1` via `putIfAbsent` so an explicit `_id` sort from the caller is preserved.

## Test plan

- [x] `MongoQueryTranslatorTest.sorting should append a unique _id tiebreaker to keep pagination stable`
- [x] `MongoFlowQueryRepositoryTest.paged query pipeline should sort with unique tiebreaker before skip and limit`