### PR TITLE
#405 Verify dual-line publication coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    [Issue #145](https://github.com/lisegmbh/fluxflow/issues/145)
 
 ### Changed
-1. **Spring Boot 4 variants now use Jackson 3**<br/>
+1. **Spring integration artifacts are now published in two explicit lines**<br/>
+   All Spring Boot integration artifacts are now published under coordinates that carry the supported
+   Spring Boot major version: `*-spring3` for Spring Boot 3 (e.g. `de.lise.fluxflow:springboot-spring3`)
+   and `*-spring4` for Spring Boot 4 (e.g. `de.lise.fluxflow:springboot-spring4`).
+   The historical, unsuffixed coordinates (e.g. `de.lise.fluxflow:springboot`) are legacy Boot 3-only
+   releases and will not receive new versions - migrate to the `-spring3` coordinates when upgrading.
+   Core artifacts remain Spring-agnostic and keep their unsuffixed coordinates.
+   Both lines are released together, and the build now verifies the published coordinates
+   before anything is published.
+   [Issue #401](https://github.com/lisegmbh/fluxflow/issues/401),
+   [Issue #402](https://github.com/lisegmbh/fluxflow/issues/402),
+   [Issue #405](https://github.com/lisegmbh/fluxflow/issues/405)
+2. **Spring Boot 4 variants now use Jackson 3**<br/>
    The `-spring4` variant of `springboot-web` now consumes Spring Boot 4's auto-configured
    Jackson 3 `ObjectMapper` (`tools.jackson.databind.ObjectMapper`) instead of requiring a
    Jackson 2 `com.fasterxml.jackson.databind.ObjectMapper` bean, which Spring Boot 4 no longer auto-configures.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
 - [Writing Commit Messages](#memo-writing-commit-messages)
 - [Code Review](#white_check_mark-code-review)
 - [Coding Style](#nail_care-coding-style)
+- [Publishing Model](#package-publishing-model)
 - [Certificate of Origin](#medal_sports-certificate-of-origin)
 - [Credits](#pray-credits)
 
@@ -165,6 +166,41 @@ For example, if all private properties are prefixed with an underscore `_`, then
 
 Adhere to the current styling and formatting of the codebase,
 but feel free to insert custom linebreaks, spacing or indentation as long as it improves readability. 
+
+## :package: Publishing Model
+
+FluxFlow publishes its Spring Boot integration artifacts in **two explicit compatibility lines**,
+built from the module trees in `library/`:
+
+| Module tree           | Published artifactId | Spring Boot baseline |
+|-----------------------|----------------------|----------------------|
+| `library/springboot`  | `<module>-spring3`   | Spring Boot 3        |
+| `library/springboot4` | `<module>-spring4`   | Spring Boot 4        |
+| `library/core`        | `<module>` (unsuffixed) | none (Spring-agnostic) |
+
+The mapping and the per-line Spring Boot BOM selection are centralized in `library/build.gradle.kts`.
+Historical, unsuffixed Spring integration coordinates (e.g. `de.lise.fluxflow:springboot`) are
+**legacy** and must never receive new releases.
+
+Both lines are released together from this repository by the Jenkins pipeline (`Jenkinsfile`):
+pushes to `develop` publish snapshots to the lise Nexus repository, and version tags (`vX.Y.Z`)
+publish releases to Maven Central.
+
+The Gradle task `verifyPublications` (provided by the `fluxflow.publication-verification`
+convention plugin in `library/buildSrc`) guards this model. It runs as part of
+`check`/`build` and before any remote publication, and fails the build if:
+
+- a publication's coordinates do not match the tree-based convention above,
+- a module exists in only one of the two Spring line trees,
+- a module depends on a module from the other Spring line, or a core module
+  depends on a Spring integration module.
+
+When **adding a new Spring integration module**, add it to **both** trees
+(`springboot:` *and* `springboot4:`) in `library/settings.gradle.kts` — the verification
+will fail the build otherwise.
+
+The verification itself is covered by Gradle TestKit tests in `library/buildSrc`.
+Run them with `./gradlew buildSrc:test` (CI runs them alongside `build`).
 
 ## :medal_sports: Certificate of Origin
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,9 @@ pipeline {
             steps {
                 container('gradle') {
                     dir('library') {
-                        sh 'gradle build'
+                        // buildSrc:test must be requested explicitly - Gradle no longer
+                        // runs buildSrc tests as part of the main build.
+                        sh 'gradle build buildSrc:test'
                     }
                 }
             }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.dokka") version "2.2.0"
     id("io.spring.dependency-management") version "1.1.7"
     id("com.vanniktech.maven.publish") version "0.37.0"
+    id("fluxflow.publication-verification")
 }
 
 repositories {
@@ -173,4 +174,11 @@ subprojects {
             }
         }
     }
+}
+
+// The publishing plugin is only applied to the root project to make its typed
+// accessors available within the subprojects block. The root project itself
+// must never publish (it would surface as an empty "de.lise.fluxflow:fluxflow").
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    enabled = false
 }

--- a/library/buildSrc/build.gradle.kts
+++ b/library/buildSrc/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(gradleTestKit())
+    testImplementation("org.assertj:assertj-core:3.27.7")
+
+    testImplementation(platform("org.junit:junit-bom:6.1.1"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/library/buildSrc/src/main/kotlin/fluxflow.publication-verification.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.publication-verification.gradle.kts
@@ -1,0 +1,84 @@
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
+// A module's Spring line is defined by the tree it lives in. Core modules (null)
+// are Spring-agnostic and must not depend on either line.
+fun springLineOf(projectPath: String) = when {
+    projectPath.startsWith(":springboot4:") -> "-spring4"
+    projectPath.startsWith(":springboot:") -> "-spring3"
+    else -> null
+}
+
+val verifyPublications = tasks.register("verifyPublications") {
+    group = "verification"
+    description = "Verifies that all publications use the expected -spring3/-spring4 dual-line coordinates."
+    doLast {
+        val violations = mutableListOf<String>()
+        val publishedProjects = project.subprojects.filter { it.plugins.hasPlugin("maven-publish") }
+
+        publishedProjects.forEach { publishedProject ->
+            val line = springLineOf(publishedProject.path)
+            val expectedArtifactId = publishedProject.name + (line ?: "")
+
+            publishedProject.extensions.getByType(PublishingExtension::class.java)
+                .publications
+                .withType(MavenPublication::class.java)
+                .filter { it.artifactId != expectedArtifactId }
+                .forEach { publication ->
+                    violations += "${publishedProject.path} publishes as \"${publication.artifactId}\"" +
+                            " but must publish as \"$expectedArtifactId\"."
+                }
+
+            // Only the dependency scopes that end up in the published POM are relevant;
+            // test dependencies may cross lines (e.g. core tests using springboot-testing).
+            val publishedScopes = setOf("api", "compileOnlyApi", "implementation", "runtimeOnly")
+            publishedProject.configurations
+                .filter { it.name in publishedScopes }
+                .flatMap { it.dependencies.withType(ProjectDependency::class.java) }
+                .map { it.path }
+                .distinct()
+                .filter { dependencyPath -> springLineOf(dependencyPath).let { it != null && it != line } }
+                .forEach { dependencyPath ->
+                    violations += "${publishedProject.path} must not depend on \"$dependencyPath\"" +
+                            " (different Spring line)."
+                }
+        }
+
+        val spring3Modules = publishedProjects.filter { it.path.startsWith(":springboot:") }.map { it.name }.toSet()
+        val spring4Modules = publishedProjects.filter { it.path.startsWith(":springboot4:") }.map { it.name }.toSet()
+        (spring3Modules - spring4Modules).forEach { moduleName ->
+            violations += "Module \"$moduleName\" is missing from the -spring4 line (springboot4 tree)."
+        }
+        (spring4Modules - spring3Modules).forEach { moduleName ->
+            violations += "Module \"$moduleName\" is missing from the -spring3 line (springboot tree)."
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Publication verification failed:\n" + violations.joinToString("\n") { " - $it" }
+            )
+        }
+        val publicationCount = publishedProjects.sumOf { publishedProject ->
+            publishedProject.extensions.getByType(PublishingExtension::class.java)
+                .publications.withType(MavenPublication::class.java).size
+        }
+        logger.lifecycle("Verified $publicationCount publications: ${spring3Modules.size}x -spring3, ${spring4Modules.size}x -spring4.")
+    }
+}
+
+// Runs with every regular build, so violations surface long before a release.
+pluginManager.withPlugin("lifecycle-base") {
+    tasks.named("check") {
+        dependsOn(verifyPublications)
+    }
+}
+
+// Remote publications (snapshot repository and Maven Central) must not run
+// if the dual-line coordinate verification fails.
+allprojects {
+    tasks.withType<PublishToMavenRepository>().configureEach {
+        dependsOn(verifyPublications)
+    }
+}

--- a/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/PublicationVerificationTest.kt
+++ b/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/PublicationVerificationTest.kt
@@ -1,0 +1,138 @@
+package de.lise.fluxflow.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class PublicationVerificationTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    @Test
+    fun `verifyPublications should accept a build that follows the dual-line convention`() {
+        // The cross-line test dependency must be tolerated (e.g. core tests using springboot-testing).
+        fixture(
+            Module("core:api", "api", testDependencies = listOf(":springboot:springboot-web")),
+            Module("springboot:springboot-web", "springboot-web-spring3"),
+            Module("springboot4:springboot-web", "springboot-web-spring4"),
+        )
+
+        val result = verify().build()
+
+        assertThat(result.output).contains("Verified 3 publications: 1x -spring3, 1x -spring4.")
+    }
+
+    @Test
+    fun `verifyPublications should reject a publication whose artifactId is missing the line suffix`() {
+        fixture(
+            Module("springboot:springboot-web", "springboot-web"),
+            Module("springboot4:springboot-web", "springboot-web-spring4"),
+        )
+
+        val result = verify().buildAndFail()
+
+        assertThat(result.output).contains(
+            ":springboot:springboot-web publishes as \"springboot-web\"" +
+                    " but must publish as \"springboot-web-spring3\"."
+        )
+    }
+
+    @Test
+    fun `verifyPublications should reject a module that only exists in one Spring line`() {
+        fixture(
+            Module("springboot:springboot-web", "springboot-web-spring3"),
+            Module("springboot:springboot-extra", "springboot-extra-spring3"),
+            Module("springboot4:springboot-web", "springboot-web-spring4"),
+        )
+
+        val result = verify().buildAndFail()
+
+        assertThat(result.output).contains(
+            "Module \"springboot-extra\" is missing from the -spring4 line (springboot4 tree)."
+        )
+    }
+
+    @Test
+    fun `verifyPublications should reject a published dependency onto the other Spring line`() {
+        fixture(
+            Module("springboot:springboot-web", "springboot-web-spring3"),
+            Module(
+                "springboot4:springboot-web",
+                "springboot-web-spring4",
+                dependencies = listOf(":springboot:springboot-web"),
+            ),
+        )
+
+        val result = verify().buildAndFail()
+
+        assertThat(result.output).contains(
+            ":springboot4:springboot-web must not depend on \":springboot:springboot-web\" (different Spring line)."
+        )
+    }
+
+    @Test
+    fun `verifyPublications should reject a core module depending on a Spring line`() {
+        fixture(
+            Module("core:api", "api", dependencies = listOf(":springboot:springboot-web")),
+            Module("springboot:springboot-web", "springboot-web-spring3"),
+            Module("springboot4:springboot-web", "springboot-web-spring4"),
+        )
+
+        val result = verify().buildAndFail()
+
+        assertThat(result.output).contains(
+            ":core:api must not depend on \":springboot:springboot-web\" (different Spring line)."
+        )
+    }
+
+    private data class Module(
+        val path: String,
+        val artifactId: String,
+        val dependencies: List<String> = emptyList(),
+        val testDependencies: List<String> = emptyList(),
+    )
+
+    private fun fixture(vararg modules: Module) {
+        File(projectDir, "settings.gradle").writeText(
+            "rootProject.name = 'fixture'\n" +
+                    modules.joinToString("\n") { "include '${it.path}'" }
+        )
+        File(projectDir, "build.gradle").writeText(
+            "plugins { id 'fluxflow.publication-verification' }"
+        )
+        modules.forEach { module ->
+            val moduleDir = File(projectDir, module.path.replace(':', '/'))
+            moduleDir.mkdirs()
+            val dependencies = module.dependencies.map { "implementation project('$it')" } +
+                    module.testDependencies.map { "testImplementation project('$it')" }
+            File(moduleDir, "build.gradle").writeText(
+                """
+                plugins {
+                    id 'java-library'
+                    id 'maven-publish'
+                }
+                group = 'de.lise.fluxflow'
+                version = '1.0.0'
+                publishing {
+                    publications {
+                        maven(MavenPublication) {
+                            from components.java
+                            artifactId = '${module.artifactId}'
+                        }
+                    }
+                }
+                dependencies {
+                    ${dependencies.joinToString("\n                    ")}
+                }
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun verify(): GradleRunner = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments("verifyPublications")
+}


### PR DESCRIPTION
The -spring3/-spring4 dual-line publishing model (#401, #402, #405) only works if every Spring integration module is published in both lines, under line-suffixed coordinates and without depending on the other line. Until now, nothing enforced this, so a drifting module tree or publishing configuration would silently ship broken coordinates.

Introduce the `fluxflow.publication-verification` convention plugin (`library/buildSrc`) providing the `verifyPublications` task, which runs with check/build and gates all remote publications. It is covered by Gradle TestKit tests; since Gradle no longer runs `buildSrc` tests on its own, CI requests `buildSrc:test `explicitly.

Also document the publishing model and its guard rails in `CONTRIBUTING.md`.