### PR TITLE
Add reproducible security baseline harness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/build/*.sh text eol=lf
+/build/tests/*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ doc/**/*.png
 doc/**/*.pdf
 doc/**/*.cache
 doc/doc.xml
+library/testcontainers-debug.txt
+
+library/testcontainers-debug2.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out/
 # Gradle
 HELP.md
 .gradle
+.kotlin/
 build/
 !/build
 !gradle/wrapper/gradle-wrapper.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    Adds a mandatory test gate and shared characterization fixtures for both Spring
    compatibility lines. This test infrastructure does not change production type resolution.
 
+6. **Docker runtime for Jenkins integration tests**<br/>
+   Provides a per-agent Docker sidecar through a shared Unix socket, checks readiness from
+   the Gradle container, and retains test reports on build failures. Security-test exceptions
+   include their full causes in the build log. The Kubernetes cluster must permit the
+   privileged Docker sidecar.
+
 ### Changed
 1. **Spring integration artifacts are now published in two explicit lines**<br/>
    All Spring Boot integration artifacts are now published under coordinates that carry the supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    and merges data listeners from the imported and parent step, 
    reducing duplication and improving maintainability.
    [Issue #145](https://github.com/lisegmbh/fluxflow/issues/145)
+3. **Shared security baseline tests**<br/>
+   Adds a mandatory test gate and shared characterization fixtures for both Spring
+   compatibility lines. This test infrastructure does not change production type resolution.
 
 ### Changed
 1. **Spring integration artifacts are now published in two explicit lines**<br/>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
             defaultContainer 'jnlp'
             inheritFrom 'plain'
             yamlFile './build/agent.yml'
+            showRawYaml true
         }
     }
 
@@ -20,11 +21,23 @@ pipeline {
             }
             steps {
                 container('gradle') {
+                    sh 'sh build/tests/wait-for-docker-test.sh'
+                    sh 'sh build/wait-for-docker.sh'
                     dir('library') {
                         // buildSrc:test must be requested explicitly - Gradle no longer
                         // runs buildSrc tests as part of the main build.
                         sh 'gradle build buildSrc:test'
                     }
+                }
+            }
+            post {
+                always {
+                    // Preflight can fail before XML exists. The mandatory Gradle
+                    // security gate still rejects absent or skipped security tests.
+                    junit testResults: 'library/**/build/test-results/**/*.xml',
+                            allowEmptyResults: true
+                    archiveArtifacts artifacts: 'library/**/build/reports/tests/**,library/**/build/test-results/**/*.xml',
+                            allowEmptyArchive: true
                 }
             }
         }

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,68 @@
+# Jenkins test runtime
+
+`Jenkinsfile` loads `build/agent.yml` and inherits the Jenkins Kubernetes pod template `plain`.
+The local template adds a Docker-in-Docker sidecar alongside the existing Gradle container.
+The generated pod YAML is printed in the Jenkins log so inherited settings can be checked.
+
+## Connection and lifecycle
+
+- Only the Docker sidecar requests `privileged: true` and runs as root. The Kubernetes cluster
+  must permit this container; a pod admission rejection cannot be fixed by skipping tests.
+- Docker listens only on `unix:///var/run/fluxflow-docker/docker.sock`. Starting the official
+  entrypoint with an explicit `dockerd` argument avoids its automatic TCP listener configuration.
+- A pod-local `emptyDir` shares the socket. Socket group 1000 matches the Gradle container's
+  effective group; its user ID remains inherited. Docker state uses separate ephemeral volumes.
+  No host Docker socket or host filesystem is mounted.
+- `TESTCONTAINERS_HOST_OVERRIDE=localhost` addresses published Mongo/Ryuk ports in the shared
+  pod network. `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` gives Ryuk the daemon-side socket path.
+- The sidecar readiness probe uses `docker info`. Before Gradle starts, `wait-for-docker.sh`
+  also checks the API using the Gradle user's actual Unix-socket permissions. It accepts only
+  an HTTP-success response containing `OK` from `/_ping`.
+- The default preflight makes at most 30 requests, each limited to two seconds, with two seconds
+  between attempts. `DOCKER_WAIT_ATTEMPTS` and `DOCKER_WAIT_INTERVAL_SECONDS` control this bound.
+- Testcontainers owns the test Mongo containers and Ryuk performs cleanup. Deleting the agent
+  pod also removes its daemon and ephemeral data volumes.
+
+The Docker sidecar has a 500m CPU / 1Gi memory request because its daemon hosts the test database
+processes. These requests are scheduling reservations, not hard limits. Actual cluster limits and
+the inherited pod configuration must be checked on the Jenkins run.
+
+## Tests and failure evidence
+
+Run the readiness command's behavioral tests from a POSIX shell:
+
+```sh
+sh build/tests/wait-for-docker-test.sh
+```
+
+They replace only the HTTP client at the process boundary and cover readiness, delayed startup,
+persistent socket failure, wrong response, HTTP errors, wrong transport, invalid retry settings
+and a missing HTTP client. Jenkins runs these tests before the real API preflight.
+
+The authoritative integration check remains the full library build, including both mandatory
+Mongo `securityTest` tasks and `buildSrc:test`. Readiness alone does not prove image pulls, Mongo
+mapped-port access, replica-set behavior, or Ryuk cleanup. Security-test failures print full
+exception causes and stack traces.
+
+The build stage publishes JUnit results and archives test reports even on failure. Empty report
+publication is tolerated only to keep a preflight failure understandable; the Gradle security
+gate still fails on absent required tests/reports, failed tests or skipped tests. Its requirements
+are unchanged.
+
+For the first Jenkins run, distinguish:
+
+1. **Agent pod rejected:** inspect the provisioning log for the privileged-container policy.
+2. **Sidecar not ready:** inspect the `docker` container log for daemon, storage or inherited
+   security-context errors.
+3. **Gradle preflight fails:** inspect its last HTTP/socket error and the effective group/mounts.
+4. **Tests fail after readiness:** inspect the archived XML and full Testcontainers exception;
+   check registry/image pulls, API compatibility and mapped-port access.
+
+Do not disable the security gate or Ryuk to obtain a successful build. The separate scheduling
+timing-test issue and pinned mandatory Mongo-fixture follow-up are not changed by this runtime PR.
+
+## Reference
+
+- [Official Docker entrypoint](https://github.com/docker-library/docker/blob/master/29/dind/dockerd-entrypoint.sh)
+- [Testcontainers Docker configuration](https://java.testcontainers.org/features/configuration/)
+- [Jenkins Kubernetes pod templates](https://plugins.jenkins.io/kubernetes/)

--- a/build/agent.yml
+++ b/build/agent.yml
@@ -4,6 +4,25 @@ spec:
   containers:
     - name: gradle
       image: gradle:9.7.1-jdk17
+      securityContext:
+        # Match the Docker socket group without changing the inherited build UID.
+        runAsGroup: 1000
+      env:
+        - name: DOCKER_HOST
+          value: unix:///var/run/fluxflow-docker/docker.sock
+        - name: DOCKER_TLS_VERIFY
+          value: ""
+        - name: DOCKER_CERT_PATH
+          value: ""
+        # Published ports belong to the sidecar, which shares this pod's network.
+        - name: TESTCONTAINERS_HOST_OVERRIDE
+          value: localhost
+        # Ryuk mounts this path from the Docker daemon's filesystem.
+        - name: TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE
+          value: /var/run/fluxflow-docker/docker.sock
+      volumeMounts:
+        - name: docker-socket
+          mountPath: /var/run/fluxflow-docker
       command:
         - cat
       tty: true
@@ -11,3 +30,48 @@ spec:
         requests:
           cpu: 500m
           memory: 500Mi
+    - name: docker
+      image: docker:29.8.0-dind
+      securityContext:
+        privileged: true
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+      command:
+        - dockerd-entrypoint.sh
+      args:
+        # Explicit dockerd avoids the entrypoint's automatic TCP listeners.
+        - dockerd
+        - --host=unix:///var/run/fluxflow-docker/docker.sock
+        - --group=1000
+      env:
+        - name: DOCKER_HOST
+          value: unix:///var/run/fluxflow-docker/docker.sock
+        - name: DOCKER_TLS_VERIFY
+          value: ""
+        - name: DOCKER_CERT_PATH
+          value: ""
+      volumeMounts:
+        - name: docker-socket
+          mountPath: /var/run/fluxflow-docker
+        - name: docker-storage
+          mountPath: /var/lib/docker
+        - name: containerd-storage
+          mountPath: /var/lib/containerd
+      readinessProbe:
+        exec:
+          command: [docker, info]
+        periodSeconds: 2
+        timeoutSeconds: 5
+        failureThreshold: 60
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+  volumes:
+    - name: docker-socket
+      emptyDir: {}
+    - name: docker-storage
+      emptyDir: {}
+    - name: containerd-storage
+      emptyDir: {}

--- a/build/tests/wait-for-docker-test.sh
+++ b/build/tests/wait-for-docker-test.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+set -eu
+
+build_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+fixture_dir=$(mktemp -d)
+trap 'rm -rf "$fixture_dir"' EXIT HUP INT TERM
+mkdir "$fixture_dir/bin"
+
+# Exercise the readiness command as a subprocess. Only the Docker HTTP endpoint
+# is replaced; exit status, retries and diagnostics are observed by the caller.
+cat > "$fixture_dir/bin/curl" <<'CURL'
+#!/bin/sh
+set -eu
+previous=''
+socket=''
+for argument in "$@"; do
+    if [ "$previous" = '--unix-socket' ]; then socket=$argument; fi
+    previous=$argument
+done
+[ "$socket" = '/var/run/fluxflow-docker/docker.sock' ] || exit 91
+[ "$previous" = 'http://localhost/_ping' ] || exit 92
+calls=0
+if [ -f "$DOCKER_TEST_CALLS" ]; then calls=$(cat "$DOCKER_TEST_CALLS"); fi
+calls=$((calls + 1))
+printf '%s' "$calls" > "$DOCKER_TEST_CALLS"
+case "$DOCKER_TEST_MODE" in
+    ready) printf 'OK' ;;
+    delayed)
+        if [ "$calls" -lt 3 ]; then printf 'Connection refused' >&2; exit 7; fi
+        printf 'OK'
+        ;;
+    unavailable) printf 'Permission denied opening socket' >&2; exit 7 ;;
+    http-error) printf 'HTTP 503' >&2; exit 22 ;;
+    wrong-service) printf 'Not Docker' ;;
+    *) exit 93 ;;
+esac
+CURL
+chmod +x "$fixture_dir/bin/curl"
+
+export PATH="$fixture_dir/bin:$PATH"
+export DOCKER_HOST='unix:///var/run/fluxflow-docker/docker.sock'
+export DOCKER_WAIT_ATTEMPTS=3
+export DOCKER_WAIT_INTERVAL_SECONDS=0
+export DOCKER_TEST_CALLS="$fixture_dir/calls"
+
+run_case() {
+    DOCKER_TEST_MODE=$1
+    export DOCKER_TEST_MODE
+    rm -f "$DOCKER_TEST_CALLS"
+    status=0
+    sh "$build_dir/wait-for-docker.sh" > "$fixture_dir/output" 2>&1 || status=$?
+}
+
+assert_status() {
+    if [ "$status" -ne "$1" ]; then
+        cat "$fixture_dir/output" >&2
+        printf 'FAIL: %s (exit %s, expected %s)\n' "$DOCKER_TEST_MODE" "$status" "$1" >&2
+        exit 1
+    fi
+}
+
+run_case ready
+assert_status 0
+[ "$(cat "$DOCKER_TEST_CALLS")" = 1 ]
+grep -q 'Docker is ready' "$fixture_dir/output"
+printf 'PASS: ready daemon permits the build\n'
+
+run_case delayed
+assert_status 0
+[ "$(cat "$DOCKER_TEST_CALLS")" = 3 ]
+printf 'PASS: delayed daemon is retried\n'
+
+run_case unavailable
+assert_status 1
+[ "$(cat "$DOCKER_TEST_CALLS")" = 3 ]
+grep -q 'Permission denied' "$fixture_dir/output"
+grep -q 'Docker did not become ready' "$fixture_dir/output"
+printf 'PASS: unavailable daemon fails with the cause after bounded retries\n'
+
+run_case wrong-service
+assert_status 1
+printf 'PASS: an unrelated HTTP response is not readiness\n'
+
+run_case http-error
+assert_status 1
+grep -q 'HTTP 503' "$fixture_dir/output"
+printf 'PASS: an HTTP error does not permit the build\n'
+
+DOCKER_HOST='tcp://localhost:2375'
+run_case ready
+assert_status 1
+[ ! -f "$DOCKER_TEST_CALLS" ]
+printf 'PASS: this sidecar preflight rejects an unexpected transport\n'
+
+DOCKER_HOST='unix:///var/run/fluxflow-docker/docker.sock'
+DOCKER_WAIT_ATTEMPTS=0
+run_case ready
+assert_status 1
+[ ! -f "$DOCKER_TEST_CALLS" ]
+printf 'PASS: invalid retry configuration fails immediately\n'
+
+rm "$fixture_dir/bin/curl"
+DOCKER_WAIT_ATTEMPTS=3
+status=0
+PATH="$fixture_dir/bin" /bin/sh "$build_dir/wait-for-docker.sh" > "$fixture_dir/output" 2>&1 || status=$?
+assert_status 1
+grep -q 'needs curl' "$fixture_dir/output"
+printf 'PASS: a missing HTTP client has an actionable error\n'

--- a/build/wait-for-docker.sh
+++ b/build/wait-for-docker.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+# Run from the Gradle container, so this also checks the build user's socket access.
+case "${DOCKER_HOST:-}" in
+    unix:///*) socket=${DOCKER_HOST#unix://} ;;
+    *) printf 'Expected DOCKER_HOST to name the shared Unix socket.\n' >&2; exit 1 ;;
+esac
+
+attempts=${DOCKER_WAIT_ATTEMPTS:-30}
+interval=${DOCKER_WAIT_INTERVAL_SECONDS:-2}
+case "$attempts" in
+    ''|*[!0-9]*|0) printf 'DOCKER_WAIT_ATTEMPTS must be positive.\n' >&2; exit 1 ;;
+esac
+case "$interval" in
+    ''|*[!0-9]*) printf 'DOCKER_WAIT_INTERVAL_SECONDS must be nonnegative.\n' >&2; exit 1 ;;
+esac
+if ! command -v curl >/dev/null 2>&1; then
+    printf 'The Gradle image needs curl for the Docker readiness check.\n' >&2
+    exit 1
+fi
+
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+    response=''
+    if response=$(curl --noproxy '*' --fail --silent --show-error --max-time 2 \
+        --unix-socket "$socket" http://localhost/_ping 2>&1) && [ "$response" = 'OK' ]; then
+        printf 'Docker is ready through %s.\n' "$DOCKER_HOST"
+        exit 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then sleep "$interval"; fi
+    attempt=$((attempt + 1))
+done
+
+printf 'Docker did not become ready after %s attempts: %s\n' "$attempts" "$response" >&2
+printf 'Check the docker sidecar log, privileged-container policy and socket permissions.\n' >&2
+exit 1

--- a/library/buildSrc/src/main/kotlin/de/lise/fluxflow/gradle/MandatorySecurityTest.kt
+++ b/library/buildSrc/src/main/kotlin/de/lise/fluxflow/gradle/MandatorySecurityTest.kt
@@ -1,0 +1,14 @@
+package de.lise.fluxflow.gradle
+
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.testing.Test
+
+/** Keeps Gradle's command-line test selection from weakening the mandatory gate. */
+abstract class MandatorySecurityTest : Test() {
+    override fun setTestNameIncludePatterns(testNamePattern: List<String>): Test {
+        if (testNamePattern.isNotEmpty()) {
+            throw GradleException("Security baseline does not allow test filters; run the regular test task for diagnostics.")
+        }
+        return super.setTestNameIncludePatterns(testNamePattern)
+    }
+}

--- a/library/buildSrc/src/main/kotlin/de/lise/fluxflow/gradle/SecurityTestRequirements.kt
+++ b/library/buildSrc/src/main/kotlin/de/lise/fluxflow/gradle/SecurityTestRequirements.kt
@@ -1,0 +1,8 @@
+package de.lise.fluxflow.gradle
+
+import org.gradle.api.provider.ListProperty
+
+/** Declares the baseline suites that must participate in every security gate run. */
+abstract class SecurityTestRequirements {
+    abstract val requiredClasses: ListProperty<String>
+}

--- a/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
@@ -49,6 +49,11 @@ val securityTest = tasks.register<MandatorySecurityTest>("securityTest") {
     classpath = testSources.get().runtimeClasspath
     include(baselinePattern)
     useJUnitPlatform()
+    testLogging {
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showCauses = true
+        showStackTraces = true
+    }
     // Container availability is external state and is not represented by Gradle inputs.
     outputs.upToDateWhen { false }
     outputs.cacheIf { false }

--- a/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
@@ -56,13 +56,29 @@ val securityTest = tasks.register<Test>("securityTest") {
         }
     }
     addTestListener(object : TestListener {
+        private val executedClasses = mutableSetOf<String>()
+
         override fun beforeSuite(suite: TestDescriptor) = Unit
         override fun beforeTest(test: TestDescriptor) = Unit
-        override fun afterTest(test: TestDescriptor, result: TestResult) = Unit
+        override fun afterTest(test: TestDescriptor, result: TestResult) {
+            test.className?.let { executedClasses.add(it) }
+        }
 
         override fun afterSuite(suite: TestDescriptor, result: TestResult) {
             if (suite.parent == null && result.skippedTestCount > 0) {
                 throw GradleException("Security baseline must execute without skipped tests.")
+            }
+            if (suite.parent == null) {
+                if (result.testCount == 0L) {
+                    throw GradleException("Security baseline must execute at least one test.")
+                }
+                if (result.failedTestCount > 0) {
+                    throw GradleException("Security baseline must execute without failed tests.")
+                }
+                val missingClasses = securityRequirements.requiredClasses.get() - executedClasses
+                if (missingClasses.isNotEmpty()) {
+                    throw GradleException("Required security baseline classes did not execute: ${missingClasses.joinToString()}.")
+                }
             }
         }
     })

--- a/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
@@ -1,9 +1,11 @@
 import de.lise.fluxflow.gradle.SecurityTestRequirements
+import de.lise.fluxflow.gradle.MandatorySecurityTest
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 
 plugins {
     java
@@ -19,7 +21,14 @@ securityRequirements.requiredClasses.convention(emptyList())
 val verifySecurityTestClasses = tasks.register("verifySecurityTestClasses") {
     dependsOn(tasks.named("testClasses"))
     doLast {
-        val classes = tasks.named<Test>("securityTest").get().candidateClassFiles
+        val securityTask = tasks.named<Test>("securityTest").get()
+        val platformOptions = securityTask.options as? JUnitPlatformOptions
+        if (securityTask.filter.includePatterns.isNotEmpty() || securityTask.filter.excludePatterns.isNotEmpty() ||
+            platformOptions?.includeTags?.isNotEmpty() == true || platformOptions?.excludeTags?.isNotEmpty() == true
+        ) {
+            throw GradleException("Security baseline does not allow test filters; run the regular test task for diagnostics.")
+        }
+        val classes = securityTask.candidateClassFiles
         if (classes.isEmpty) {
             throw GradleException("Security baseline classes are missing.")
         }
@@ -32,7 +41,7 @@ val verifySecurityTestClasses = tasks.register("verifySecurityTestClasses") {
     }
 }
 
-val securityTest = tasks.register<Test>("securityTest") {
+val securityTest = tasks.register<MandatorySecurityTest>("securityTest") {
     description = "Runs the mandatory security baseline tests."
     group = "verification"
     dependsOn(verifySecurityTestClasses)

--- a/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
@@ -1,0 +1,64 @@
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestListener
+import org.gradle.api.tasks.testing.TestResult
+
+plugins {
+    java
+}
+
+val testSources = extensions.getByType<SourceSetContainer>().named("test")
+val baselinePattern = "de/lise/fluxflow/mongo/security/baseline/**"
+
+// Test actions do not run for NO-SOURCE, so this prerequisite validates the
+// compiled baseline before Gradle can skip the Test task.
+val verifySecurityTestClasses = tasks.register("verifySecurityTestClasses") {
+    dependsOn(tasks.named("testClasses"))
+    doLast {
+        val classes = tasks.named<Test>("securityTest").get().candidateClassFiles
+        if (classes.isEmpty) {
+            throw GradleException("Security baseline classes are missing.")
+        }
+    }
+}
+
+val securityTest = tasks.register<Test>("securityTest") {
+    description = "Runs the mandatory security baseline tests."
+    group = "verification"
+    dependsOn(verifySecurityTestClasses)
+    testClassesDirs = testSources.get().output.classesDirs
+    classpath = testSources.get().runtimeClasspath
+    include(baselinePattern)
+    useJUnitPlatform()
+    // Container availability is external state and is not represented by Gradle inputs.
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+    doFirst {
+        if (!reports.junitXml.required.get()) {
+            throw GradleException("Security baseline XML report is required.")
+        }
+    }
+    doLast {
+        val reportsPresent = reports.junitXml.outputLocation.get().asFile
+            .listFiles { file -> file.name.startsWith("TEST-") && file.extension == "xml" }
+        if (reportsPresent.isNullOrEmpty()) {
+            throw GradleException("Security baseline XML report is required.")
+        }
+    }
+    addTestListener(object : TestListener {
+        override fun beforeSuite(suite: TestDescriptor) = Unit
+        override fun beforeTest(test: TestDescriptor) = Unit
+        override fun afterTest(test: TestDescriptor, result: TestResult) = Unit
+
+        override fun afterSuite(suite: TestDescriptor, result: TestResult) {
+            if (suite.parent == null && result.skippedTestCount > 0) {
+                throw GradleException("Security baseline must execute without skipped tests.")
+            }
+        }
+    })
+}
+
+tasks.named("check") {
+    dependsOn(securityTest)
+}

--- a/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
+++ b/library/buildSrc/src/main/kotlin/fluxflow.security-tests.gradle.kts
@@ -1,3 +1,4 @@
+import de.lise.fluxflow.gradle.SecurityTestRequirements
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
@@ -10,6 +11,8 @@ plugins {
 
 val testSources = extensions.getByType<SourceSetContainer>().named("test")
 val baselinePattern = "de/lise/fluxflow/mongo/security/baseline/**"
+val securityRequirements = extensions.create<SecurityTestRequirements>("securityTests")
+securityRequirements.requiredClasses.convention(emptyList())
 
 // Test actions do not run for NO-SOURCE, so this prerequisite validates the
 // compiled baseline before Gradle can skip the Test task.
@@ -19,6 +22,12 @@ val verifySecurityTestClasses = tasks.register("verifySecurityTestClasses") {
         val classes = tasks.named<Test>("securityTest").get().candidateClassFiles
         if (classes.isEmpty) {
             throw GradleException("Security baseline classes are missing.")
+        }
+        val missingClasses = securityRequirements.requiredClasses.get().filter { className ->
+            classes.none { it.invariantSeparatorsPath.endsWith("/${className.replace('.', '/')}.class") }
+        }
+        if (missingClasses.isNotEmpty()) {
+            throw GradleException("Required security baseline classes were not selected: ${missingClasses.joinToString()}.")
         }
     }
 }

--- a/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
+++ b/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
@@ -108,6 +108,21 @@ class SecurityTestsTest {
         assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 
+    @Test
+    fun `security gate should reject one missing required class`() {
+        fixture("""
+            securityTests.requiredClasses = [
+                'de.lise.fluxflow.mongo.security.baseline.BaselineTest',
+                'de.lise.fluxflow.mongo.security.baseline.MongoBaselineTest'
+            ]
+        """.trimIndent())
+        baseline("@Test void baseline() {}")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Required security baseline classes were not selected", "MongoBaselineTest")
+    }
+
     private fun fixture(extra: String = "") {
         File(projectDir, "settings.gradle").writeText("rootProject.name = 'security-fixture'")
         File(projectDir, "build.gradle").writeText(

--- a/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
+++ b/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
@@ -1,0 +1,144 @@
+package de.lise.fluxflow.gradle
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SecurityTestsTest {
+    @TempDir
+    lateinit var projectDir: File
+
+    @Test
+    fun `check should run security tests and produce a report`() {
+        fixture()
+        baseline("@Test void baseline() {}")
+
+        val result = runner("check").build()
+
+        assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(File(projectDir, "build/test-results/securityTest/TEST-de.lise.fluxflow.mongo.security.baseline.BaselineTest.xml"))
+            .exists()
+    }
+
+    @Test
+    fun `security gate should reject skipped tests`() {
+        fixture()
+        baseline("@Test @Disabled void skipped() {} @Test void passing() {}")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline must execute without skipped tests")
+    }
+
+    @Test
+    fun `security gate should reject missing sources instead of reporting NO-SOURCE`() {
+        fixture()
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline classes are missing")
+    }
+
+    @Test
+    fun `security gate should reject an empty test selection`() {
+        fixture()
+        baseline("@Test void baseline() {}")
+
+        val result = runner("securityTest", "--tests", "MissingTest").buildAndFail()
+
+        assertThat(result.output).contains("No tests found for given includes")
+    }
+
+    @Test
+    fun `security gate should reject exclusions that remove every test class`() {
+        fixture("securityTest { exclude '**/*' }")
+        baseline("@Test void baseline() {}")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline classes are missing")
+    }
+
+    @Test
+    fun `security gate should fail an assertion`() {
+        fixture()
+        baseline("@Test void baseline() { Assertions.fail(\"regression detected\"); }")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.FAILED)
+        assertThat(result.output).contains("There were failing tests")
+    }
+
+    @Test
+    fun `security gate should fail when container initialization fails`() {
+        fixture()
+        baseline("""
+            @BeforeAll static void startContainer() { throw new IllegalStateException("container startup failed"); }
+            @Test void baseline() {}
+        """.trimIndent())
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.FAILED)
+        assertThat(result.output).contains("There were failing tests")
+    }
+
+    @Test
+    fun `security gate should require XML evidence`() {
+        fixture("securityTest { reports.junitXml.required = false }")
+        baseline("@Test void baseline() {}")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline XML report is required")
+    }
+
+    @Test
+    fun `security gate should execute again even when inputs are unchanged`() {
+        fixture()
+        baseline("@Test void baseline() {}")
+        runner("securityTest").build()
+
+        val result = runner("securityTest", "--build-cache").build()
+
+        assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    private fun fixture(extra: String = "") {
+        File(projectDir, "settings.gradle").writeText("rootProject.name = 'security-fixture'")
+        File(projectDir, "build.gradle").writeText(
+            """
+            plugins { id 'java'; id 'fluxflow.security-tests' }
+            repositories { mavenCentral() }
+            dependencies {
+                testImplementation platform('org.junit:junit-bom:6.1.3')
+                testImplementation 'org.junit.jupiter:junit-jupiter'
+                testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+            }
+            tasks.withType(Test).configureEach { useJUnitPlatform() }
+            $extra
+            """.trimIndent()
+        )
+    }
+
+    private fun baseline(body: String) {
+        val source = File(projectDir, "src/test/java/de/lise/fluxflow/mongo/security/baseline/BaselineTest.java")
+        source.parentFile.mkdirs()
+        source.writeText(
+            """
+            package de.lise.fluxflow.mongo.security.baseline;
+            import org.junit.jupiter.api.*;
+            public class BaselineTest { $body }
+            """.trimIndent()
+        )
+    }
+
+    private fun runner(vararg arguments: String) = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withPluginClasspath()
+        .withArguments(*arguments, "--stacktrace")
+}

--- a/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
+++ b/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
@@ -49,7 +49,7 @@ class SecurityTestsTest {
 
         val result = runner("securityTest", "--tests", "MissingTest").buildAndFail()
 
-        assertThat(result.output).contains("No tests found for given includes")
+        assertThat(result.output).contains("Security baseline must execute at least one test")
     }
 
     @Test
@@ -70,7 +70,7 @@ class SecurityTestsTest {
         val result = runner("securityTest").buildAndFail()
 
         assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.FAILED)
-        assertThat(result.output).contains("There were failing tests")
+        assertThat(result.output).contains("Security baseline must execute without failed tests")
     }
 
     @Test
@@ -84,7 +84,7 @@ class SecurityTestsTest {
         val result = runner("securityTest").buildAndFail()
 
         assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.FAILED)
-        assertThat(result.output).contains("There were failing tests")
+        assertThat(result.output).contains("Security baseline must execute without failed tests")
     }
 
     @Test
@@ -123,6 +123,85 @@ class SecurityTestsTest {
         assertThat(result.output).contains("Required security baseline classes were not selected", "MongoBaselineTest")
     }
 
+    @Test
+    fun `security gate should reject a filter that omits a required suite`() {
+        fixture("""
+            securityTests.requiredClasses = [
+                'de.lise.fluxflow.mongo.security.baseline.BaselineTest',
+                'de.lise.fluxflow.mongo.security.baseline.MongoBaselineTest'
+            ]
+        """.trimIndent())
+        baseline("@Test void baseline() {}")
+        baseline("@Test void mongo() {}", "MongoBaselineTest")
+
+        val result = runner("securityTest", "--tests", "*BaselineTest.baseline").buildAndFail()
+
+        assertThat(result.output).contains("Required security baseline classes did not execute", "MongoBaselineTest")
+    }
+
+    @Test
+    fun `security gate should reject failures even when ignoreFailures is enabled`() {
+        fixture("securityTest { ignoreFailures = true }")
+        baseline("@Test void baseline() { Assertions.fail(\"regression detected\"); }")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline must execute without failed tests")
+    }
+
+    @Test
+    fun `security gate should reject zero executed tests even when Gradle allows empty discovery`() {
+        fixture("securityTest { failOnNoDiscoveredTests = false }")
+        baseline("void notATest() {}")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline must execute at least one test")
+    }
+
+    @Test
+    fun `security gate should accept all required suites executing`() {
+        fixture("""
+            securityTests.requiredClasses = [
+                'de.lise.fluxflow.mongo.security.baseline.BaselineTest',
+                'de.lise.fluxflow.mongo.security.baseline.MongoBaselineTest'
+            ]
+        """.trimIndent())
+        baseline("@Test void baseline() {}")
+        baseline("@Test void mongo() {}", "MongoBaselineTest")
+
+        val result = runner("securityTest").build()
+
+        assertThat(result.task(":securityTest")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `security gate should reject method filters inside a required suite`() {
+        fixture("securityTests.requiredClasses = ['de.lise.fluxflow.mongo.security.baseline.BaselineTest']")
+        baseline("@Test void first() {} @Test void second() {}")
+
+        val result = runner("securityTest", "--tests", "*BaselineTest.first").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline does not allow test filters")
+    }
+
+    @Test
+    fun `security gate should reject excluding one required class`() {
+        fixture("""
+            securityTests.requiredClasses = [
+                'de.lise.fluxflow.mongo.security.baseline.BaselineTest',
+                'de.lise.fluxflow.mongo.security.baseline.MongoBaselineTest'
+            ]
+            securityTest { exclude '**/MongoBaselineTest.class' }
+        """.trimIndent())
+        baseline("@Test void baseline() {}")
+        baseline("@Test void mongo() {}", "MongoBaselineTest")
+
+        val result = runner("securityTest").buildAndFail()
+
+        assertThat(result.output).contains("Required security baseline classes were not selected", "MongoBaselineTest")
+    }
+
     private fun fixture(extra: String = "") {
         File(projectDir, "settings.gradle").writeText("rootProject.name = 'security-fixture'")
         File(projectDir, "build.gradle").writeText(
@@ -140,14 +219,14 @@ class SecurityTestsTest {
         )
     }
 
-    private fun baseline(body: String) {
-        val source = File(projectDir, "src/test/java/de/lise/fluxflow/mongo/security/baseline/BaselineTest.java")
+    private fun baseline(body: String, className: String = "BaselineTest") {
+        val source = File(projectDir, "src/test/java/de/lise/fluxflow/mongo/security/baseline/$className.java")
         source.parentFile.mkdirs()
         source.writeText(
             """
             package de.lise.fluxflow.mongo.security.baseline;
             import org.junit.jupiter.api.*;
-            public class BaselineTest { $body }
+            public class $className { $body }
             """.trimIndent()
         )
     }

--- a/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
+++ b/library/buildSrc/src/test/kotlin/de/lise/fluxflow/gradle/SecurityTestsTest.kt
@@ -5,6 +5,8 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 class SecurityTestsTest {
@@ -49,7 +51,7 @@ class SecurityTestsTest {
 
         val result = runner("securityTest", "--tests", "MissingTest").buildAndFail()
 
-        assertThat(result.output).contains("Security baseline must execute at least one test")
+        assertThat(result.output).contains("Security baseline does not allow test filters")
     }
 
     @Test
@@ -136,7 +138,7 @@ class SecurityTestsTest {
 
         val result = runner("securityTest", "--tests", "*BaselineTest.baseline").buildAndFail()
 
-        assertThat(result.output).contains("Required security baseline classes did not execute", "MongoBaselineTest")
+        assertThat(result.output).contains("Security baseline does not allow test filters")
     }
 
     @Test
@@ -181,6 +183,25 @@ class SecurityTestsTest {
         baseline("@Test void first() {} @Test void second() {}")
 
         val result = runner("securityTest", "--tests", "*BaselineTest.first").buildAndFail()
+
+        assertThat(result.output).contains("Security baseline does not allow test filters")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        "filter { includeTestsMatching '*BaselineTest.first' }",
+        "filter { excludeTestsMatching '*BaselineTest.second' }",
+        "useJUnitPlatform { includeTags 'fast' }",
+        "useJUnitPlatform { excludeTags 'slow' }",
+    ])
+    fun `security gate should reject configured method and tag filters`(selection: String) {
+        fixture("""
+            securityTests.requiredClasses = ['de.lise.fluxflow.mongo.security.baseline.BaselineTest']
+            securityTest { $selection }
+        """.trimIndent())
+        baseline("@Test @Tag(\"fast\") void first() {} @Test @Tag(\"slow\") void second() {}")
+
+        val result = runner("securityTest").buildAndFail()
 
         assertThat(result.output).contains("Security baseline does not allow test filters")
     }

--- a/library/security-tests/README.md
+++ b/library/security-tests/README.md
@@ -62,3 +62,19 @@ failures are expected by their parent tests, so the parent suite remains green.
 Do not weaken the gate or skip container tests to accommodate an unavailable CI
 runtime. The Jenkins agent needs a working runtime before the mandatory check can
 succeed.
+
+## Resolved dependency baseline
+
+The PR01 verification resolved the following `testRuntimeClasspath` versions.
+These versions document the framework boundary exercised by the shared tests:
+
+| Dependency | Spring Boot 3 module | Spring Boot 4 module |
+|---|---:|---:|
+| Spring Data MongoDB | 4.5.5 | 5.0.5 |
+| MongoDB synchronous driver | 5.5.2 | 5.6.5 |
+| JUnit Jupiter engine | 5.12.2 | 6.0.3 |
+| Testcontainers | 1.21.4 | 2.0.5 |
+
+Both lines run against the pinned `mongo:8.0.12` image. Testcontainers 1.21.4 is
+required on the Boot 3 line for compatibility with current Docker Engine API
+versions; the previously resolved 1.21.3 client failed before container startup.

--- a/library/security-tests/README.md
+++ b/library/security-tests/README.md
@@ -1,0 +1,64 @@
+# Security baseline tests
+
+This source directory is shared by the Spring Boot 3 and Spring Boot 4 Mongo test
+modules. It is not a published module. PR01 adds reproducible characterization
+tests, not a security fix. No production resolver or converter is changed.
+
+## Run the mandatory baseline
+
+From `library`, with JDK 17 and a working Docker-compatible container runtime:
+
+```powershell
+.\gradlew.bat :springboot:springboot-mongo:securityTest :springboot4:springboot-mongo:securityTest
+```
+
+Both module `check` tasks also run `securityTest`. The gate requires the complete
+baseline suite, rejects skips and missing test/report output, and executes again
+even when source files have not changed. A container startup failure is a failure,
+not a reason to disable tests. No production Mongo URI or data is used.
+
+The existing conditional integration tests are not the security gate. Their event
+propagation probes do not establish that untrusted types cannot be instantiated.
+
+## Contract and evidence
+
+| Plan ID | Boundary | PR01 expectation |
+|---|---|---|
+| R01 | Persisted step kind through real step activation | Characterize initialization/construction of the harmless marker |
+| R02 | Persisted job kind through real job activation | Characterize initialization/construction of the harmless marker |
+| R03 | Raw Mongo change to `model._class`, then `WorkflowPersistence.find` | Characterize materialization of the harmless model |
+| R04 | Raw Mongo change only to root `_class`, then the same read | Observe the actual root-type behavior independently of R03 |
+| R05 | Fixture in a fresh class loader | Distinguish class initialization from constructor invocation |
+| R06 | Gradle task boundary | Missing, filtered, skipped or failing required tests fail the gate |
+
+Marker fixtures record local test events only. A fresh loader is needed to repeat
+static initialization: resetting a counter cannot reset a JVM class initializer.
+Each Mongo scenario starts from a valid model and derives the collection name
+from the real Spring Data mapping. Tampering uses the raw driver; the observation
+uses the real Fluxflow persistence/activation boundary.
+
+For the separate before-fix safety demonstration, use the same scenarios with
+`-PsecurityExpectRejection=true`. That mode expects rejection and no marker event;
+it must fail on the vulnerable baseline for R01–R03. It is not the normal CI mode
+and must never be described as a successful security verification. The relevant
+fix PR replaces each temporary production characterization with a mandatory
+rejection regression; fixture positive controls remain.
+
+XML reports are written to each Mongo module's
+`build/test-results/securityTest/` directory. Record the Git revision, commands,
+resolved runtime dependencies, test counts, failures and skips with the review.
+The complete report set must contain the required suites in both compatibility
+lines. A green PR01 report means the reproduction harness works; the findings
+remain open.
+
+## Build gate tests
+
+```powershell
+.\gradlew.bat -p buildSrc test
+```
+
+These TestKit tests execute small Gradle builds. Deliberate assertion and startup
+failures are expected by their parent tests, so the parent suite remains green.
+Do not weaken the gate or skip container tests to accommodate an unavailable CI
+runtime. The Jenkins agent needs a working runtime before the mandatory check can
+succeed.

--- a/library/security-tests/src/test/java/de/lise/fluxflow/mongo/security/baseline/WitnessClassLoader.java
+++ b/library/security-tests/src/test/java/de/lise/fluxflow/mongo/security/baseline/WitnessClassLoader.java
@@ -1,0 +1,51 @@
+package de.lise.fluxflow.mongo.security.baseline;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/** Loads each harmless witness afresh, so initialization cannot leak between tests. */
+public final class WitnessClassLoader extends ClassLoader {
+    private static final String FIXTURE_PACKAGE =
+        "de.lise.fluxflow.mongo.security.baseline.fixture.";
+    private final List<String> events = new CopyOnWriteArrayList<>();
+
+    public WitnessClassLoader() {
+        super(WitnessClassLoader.class.getClassLoader());
+    }
+
+    public void record(String event) {
+        events.add(event);
+    }
+
+    public List<String> getEvents() {
+        return List.copyOf(events);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (!name.startsWith(FIXTURE_PACKAGE)) {
+            return super.loadClass(name, resolve);
+        }
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null) {
+                String resource = name.replace('.', '/') + ".class";
+                try (InputStream input = getParent().getResourceAsStream(resource)) {
+                    if (input == null) {
+                        throw new ClassNotFoundException(name);
+                    }
+                    byte[] bytes = input.readAllBytes();
+                    loaded = defineClass(name, bytes, 0, bytes.length);
+                } catch (IOException exception) {
+                    throw new ClassNotFoundException(name, exception);
+                }
+            }
+            if (resolve) {
+                resolveClass(loaded);
+            }
+            return loaded;
+        }
+    }
+}

--- a/library/security-tests/src/test/java/de/lise/fluxflow/mongo/security/baseline/fixture/ActivationWitness.java
+++ b/library/security-tests/src/test/java/de/lise/fluxflow/mongo/security/baseline/fixture/ActivationWitness.java
@@ -1,0 +1,18 @@
+package de.lise.fluxflow.mongo.security.baseline.fixture;
+
+import de.lise.fluxflow.mongo.security.baseline.WitnessClassLoader;
+
+/** Records class initialization and construction; performs no external action. */
+public final class ActivationWitness {
+    static {
+        ((WitnessClassLoader) ActivationWitness.class.getClassLoader()).record("initialized");
+    }
+
+    public ActivationWitness() {
+        ((WitnessClassLoader) ActivationWitness.class.getClassLoader()).record("constructed");
+    }
+
+    public void execute() {
+        // A valid job payload, deliberately never invoked by these activation tests.
+    }
+}

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/ActivationBaselineTest.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/ActivationBaselineTest.kt
@@ -1,0 +1,191 @@
+package de.lise.fluxflow.mongo.security.baseline
+
+import de.lise.fluxflow.api.ioc.IocProvider
+import de.lise.fluxflow.api.job.JobStatus
+import de.lise.fluxflow.api.step.Status
+import de.lise.fluxflow.api.versioning.DefaultCompatibilityTester
+import de.lise.fluxflow.api.versioning.VersionCompatibility
+import de.lise.fluxflow.api.workflow.ModelListenerDefinition
+import de.lise.fluxflow.api.workflow.WorkflowDefinition
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.api.workflow.action.WorkflowActionDefinition
+import de.lise.fluxflow.engine.job.JobActivationService
+import de.lise.fluxflow.engine.reflection.ClassLoaderProvider
+import de.lise.fluxflow.engine.step.DefaultStepActivationService
+import de.lise.fluxflow.engine.step.StepTypeResolverImpl
+import de.lise.fluxflow.engine.workflow.WorkflowImpl
+import de.lise.fluxflow.mongo.job.JobDocument
+import de.lise.fluxflow.mongo.step.StepDocument
+import de.lise.fluxflow.reflection.activation.parameter.PriorityParameterResolver
+import de.lise.fluxflow.stereotyped.continuation.ContinuationBuilder
+import de.lise.fluxflow.stereotyped.job.JobDefinitionBuilder
+import de.lise.fluxflow.stereotyped.job.parameter.ParameterDefinitionBuilder
+import de.lise.fluxflow.stereotyped.metadata.MetadataBuilder
+import de.lise.fluxflow.stereotyped.step.StepDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.action.ActionDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.action.ActionFunctionResolverImpl
+import de.lise.fluxflow.stereotyped.step.automation.AutomationDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.data.DataDefinitionBuilder
+import de.lise.fluxflow.stereotyped.step.data.DataListenerDefinitionBuilder
+import de.lise.fluxflow.stereotyped.versioning.VersionBuilder
+import de.lise.fluxflow.validation.noop.NoOpDataValidationBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+class ActivationBaselineTest {
+    @Test
+    fun `R01 persisted step kind initializes and constructs the current witness`() {
+        MongoSecurityHarness().use { harness ->
+            val workflow = workflow()
+            val identifier = UUID.randomUUID().toString()
+            val activation = stepActivationService(harness.loader)
+            harness.template.insert(
+                StepDocument(
+                    identifier,
+                    workflow.identifier.value,
+                    LegitimateStep::class.java.name,
+                    null,
+                    emptyMap(),
+                    emptyMap(),
+                    Status.Active,
+                )
+            )
+            activation.activateFromPersistence(
+                workflow,
+                requireNotNull(harness.template.findById(identifier, StepDocument::class.java)).toStepData(),
+            )
+            harness.tamper(StepDocument::class.java, identifier, "kind", WITNESS_NAME)
+            assertThat(harness.loader.events).isEmpty()
+
+            val result = runCatching {
+                activation.activateFromPersistence(
+                    workflow,
+                    requireNotNull(harness.template.findById(identifier, StepDocument::class.java)).toStepData(),
+                )
+            }
+
+            if (java.lang.Boolean.getBoolean("fluxflow.security.expectRejection")) {
+                assertThat(harness.loader.events)
+                    .describedAs("R01 must reject the persisted kind before initializing or constructing it")
+                    .isEmpty()
+                assertThat(result.isFailure).isTrue()
+            } else {
+                assertThat(result.isSuccess).isTrue()
+                assertThat(harness.loader.events).containsExactly("initialized", "constructed")
+            }
+        }
+    }
+
+    @Test
+    fun `R02 persisted job kind initializes and constructs the current witness`() {
+        MongoSecurityHarness().use { harness ->
+            val workflow = workflow()
+            val identifier = UUID.randomUUID().toString()
+            val activation = jobActivationService(harness.loader)
+            harness.template.insert(
+                JobDocument(
+                    identifier,
+                    workflow.identifier.value,
+                    LegitimateJob::class.java.name,
+                    emptyMap(),
+                    Instant.parse("2026-09-09T12:00:00Z"),
+                    null,
+                    JobStatus.Scheduled,
+                )
+            )
+            activation.activate(
+                workflow,
+                requireNotNull(harness.template.findById(identifier, JobDocument::class.java)).toJobData(),
+            )
+            harness.tamper(JobDocument::class.java, identifier, "kind", WITNESS_NAME)
+            assertThat(harness.loader.events).isEmpty()
+
+            val result = runCatching {
+                activation.activate(
+                    workflow,
+                    requireNotNull(harness.template.findById(identifier, JobDocument::class.java)).toJobData(),
+                )
+            }
+
+            if (java.lang.Boolean.getBoolean("fluxflow.security.expectRejection")) {
+                assertThat(harness.loader.events)
+                    .describedAs("R02 must reject the persisted kind before initializing or constructing it")
+                    .isEmpty()
+                assertThat(result.isFailure).isTrue()
+            } else {
+                assertThat(result.isSuccess).isTrue()
+                assertThat(harness.loader.events).containsExactly("initialized", "constructed")
+            }
+        }
+    }
+
+    private fun stepActivationService(classLoader: ClassLoader): DefaultStepActivationService {
+        val continuationBuilder = ContinuationBuilder()
+        val metadataBuilder = MetadataBuilder()
+        val parameterResolver = PriorityParameterResolver(emptyList())
+        return DefaultStepActivationService(
+            NoDependencies,
+            StepDefinitionBuilder(
+                VersionBuilder(),
+                ActionDefinitionBuilder(
+                    continuationBuilder,
+                    metadataBuilder,
+                    ActionFunctionResolverImpl(parameterResolver),
+                ),
+                DataDefinitionBuilder(
+                    DataListenerDefinitionBuilder(continuationBuilder, parameterResolver),
+                    NoOpDataValidationBuilder(),
+                    metadataBuilder,
+                ),
+                metadataBuilder,
+                AutomationDefinitionBuilder(continuationBuilder, parameterResolver),
+            ),
+            StepTypeResolverImpl(classLoader),
+            VersionCompatibility.Unknown,
+            DefaultCompatibilityTester(),
+        )
+    }
+
+    private fun jobActivationService(classLoader: ClassLoader): JobActivationService = JobActivationService(
+        NoDependencies,
+        JobDefinitionBuilder(
+            ParameterDefinitionBuilder(),
+            ContinuationBuilder(),
+            PriorityParameterResolver(emptyList()),
+            MetadataBuilder(),
+            mutableMapOf(),
+        ),
+        ClassLoaderProvider { classLoader },
+    )
+
+    private fun workflow(): WorkflowImpl<ActivationModel> = WorkflowImpl(
+        object : WorkflowDefinition<ActivationModel> {
+            override val updateListeners = emptyList<ModelListenerDefinition<ActivationModel>>()
+            override val metadata = emptyMap<String, Any>()
+            override val actions = emptyList<WorkflowActionDefinition<ActivationModel>>()
+        },
+        WorkflowIdentifier(UUID.randomUUID().toString()),
+        ActivationModel("legitimate activation"),
+        emptyMap(),
+    )
+}
+
+private object NoDependencies : IocProvider {
+    override fun <TDependency : Any> provide(type: KClass<out TDependency>): TDependency? = null
+
+    override fun provide(type: KType): Any? = null
+}
+
+class LegitimateStep {
+    fun execute() = Unit
+}
+
+class LegitimateJob {
+    fun execute() = Unit
+}
+
+private data class ActivationModel(val value: String)

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/MongoSecurityHarness.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/MongoSecurityHarness.kt
@@ -1,0 +1,91 @@
+package de.lise.fluxflow.mongo.security.baseline
+
+import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
+import com.mongodb.client.model.Filters.eq
+import com.mongodb.client.model.Updates.set
+import de.lise.fluxflow.mongo.flowquery.expression.compilation.MongoCompiler
+import de.lise.fluxflow.mongo.flowquery.expression.compilation.SubclassProviderImpl
+import de.lise.fluxflow.mongo.flowquery.repository.MongoQueryTranslator
+import de.lise.fluxflow.mongo.workflow.WorkflowMongoConfiguration
+import de.lise.fluxflow.mongo.workflow.WorkflowRepository
+import de.lise.fluxflow.mongo.workflow.query.QueryableWorkflowRepositoryImpl
+import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
+import org.assertj.core.api.Assertions.assertThat
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactory
+import org.springframework.data.repository.core.support.RepositoryComposition.RepositoryFragments
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.util.UUID
+
+/** Real Mongo mapping and Fluxflow persistence, with fixture classes isolated per read scenario. */
+internal class MongoSecurityHarness : AutoCloseable {
+    val loader = WitnessClassLoader()
+    private val container = SecurityMongoContainer()
+    private lateinit var client: MongoClient
+    val template: MongoTemplate
+    val workflows: WorkflowPersistence
+
+    init {
+        container.start()
+        try {
+            client = MongoClients.create("mongodb://${container.host}:${container.getMappedPort(27017)}")
+            template = MongoTemplate(client, "security_${UUID.randomUUID().toString().replace("-", "")}")
+            val converter = template.converter as MappingMongoConverter
+            converter.setTypeMapper(DefaultMongoTypeMapper("_class", converter.mappingContext).apply {
+                setBeanClassLoader(loader)
+            })
+            val repository = MongoRepositoryFactory(template).getRepository(
+                WorkflowRepository::class.java,
+                RepositoryFragments.just(QueryableWorkflowRepositoryImpl(template))
+            )
+            val configuration = WorkflowMongoConfiguration()
+            val translator = MongoQueryTranslator(MongoCompiler(SubclassProviderImpl(emptySet())))
+            workflows = configuration.workflowPersistence(
+                repository,
+                configuration.workflowFlowQueryRepository(
+                    translator,
+                    configuration.workflowMongoExecutor(template)
+                ),
+                configuration.workflowDocumentMapper()
+            )
+        } catch (failure: Throwable) {
+            if (::client.isInitialized) client.close()
+            container.stop()
+            throw failure
+        }
+    }
+
+    fun tamper(type: Class<*>, id: String, path: String, value: String) {
+        val collection = template.getCollection(template.getCollectionName(type))
+        val update = collection.updateOne(eq("_id", id), set(path, value))
+        assertThat(update.matchedCount).describedAs("The legitimate document exists").isEqualTo(1)
+        assertThat(update.modifiedCount).describedAs("The raw document was changed").isEqualTo(1)
+        val raw = requireNotNull(collection.find(eq("_id", id)).first())
+        val storedValue = path.split('.').fold(raw as Any?) { current, field ->
+            (current as Map<*, *>)[field]
+        }
+        assertThat(storedValue).isEqualTo(value)
+    }
+
+    override fun close() {
+        try {
+            client.close()
+        } finally {
+            container.stop()
+        }
+    }
+
+    private class SecurityMongoContainer : GenericContainer<SecurityMongoContainer>(
+        DockerImageName.parse("mongo:8.0.12")
+    ) {
+        init {
+            withExposedPorts(27017)
+            waitingFor(Wait.forListeningPort())
+        }
+    }
+}

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/SecurityWitnessTest.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/SecurityWitnessTest.kt
@@ -1,0 +1,14 @@
+package de.lise.fluxflow.mongo.security.baseline
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SecurityWitnessTest {
+    @Test
+    fun `R05 witness records initialization and construction independently`() {
+        val fixture = Class.forName(
+            "de.lise.fluxflow.mongo.security.baseline.fixture.ActivationWitness"
+        )
+        assertThat(fixture.getDeclaredConstructor().newInstance()).isNotNull()
+    }
+}

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/SecurityWitnessTest.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/SecurityWitnessTest.kt
@@ -6,9 +6,23 @@ import org.junit.jupiter.api.Test
 class SecurityWitnessTest {
     @Test
     fun `R05 witness records initialization and construction independently`() {
-        val fixture = Class.forName(
-            "de.lise.fluxflow.mongo.security.baseline.fixture.ActivationWitness"
-        )
+        val firstLoader = WitnessClassLoader()
+        val secondLoader = WitnessClassLoader()
+        val firstType = exerciseWitness(firstLoader)
+        val secondType = exerciseWitness(secondLoader)
+        assertThat(firstType).isNotSameAs(secondType)
+        assertThat(firstLoader.events).containsExactly("initialized", "constructed")
+        assertThat(secondLoader.events).containsExactly("initialized", "constructed")
+    }
+
+    private fun exerciseWitness(loader: WitnessClassLoader): Class<*> {
+        val name = "de.lise.fluxflow.mongo.security.baseline.fixture.ActivationWitness"
+        val fixture = Class.forName(name, false, loader)
+        assertThat(loader.events).isEmpty()
+        Class.forName(name, true, loader)
+        assertThat(loader.events).containsExactly("initialized")
         assertThat(fixture.getDeclaredConstructor().newInstance()).isNotNull()
+        assertThat(loader.events).containsExactly("initialized", "constructed")
+        return fixture
     }
 }

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/WorkflowModelBaselineTest.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/WorkflowModelBaselineTest.kt
@@ -1,0 +1,38 @@
+package de.lise.fluxflow.mongo.security.baseline
+
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.mongo.workflow.WorkflowDocument
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class WorkflowModelBaselineTest {
+    @Test
+    fun `R03 nested model type is materialized by the current workflow persistence`() {
+        MongoSecurityHarness().use { harness ->
+            val identifier = WorkflowIdentifier(UUID.randomUUID().toString())
+            val model = BaselineModel("legitimate model")
+            harness.workflows.create(model, identifier)
+            assertThat(harness.workflows.find(identifier)?.model).isEqualTo(model)
+            harness.tamper(WorkflowDocument::class.java, identifier.value, "model._class", WITNESS_NAME)
+            assertThat(harness.loader.events).isEmpty()
+
+            val read = runCatching { harness.workflows.find(identifier) }
+
+            if (java.lang.Boolean.getBoolean("fluxflow.security.expectRejection")) {
+                assertThat(harness.loader.events)
+                    .describedAs("R03 must reject the persisted type before initializing or constructing it")
+                    .isEmpty()
+                assertThat(read.isFailure).isTrue()
+            } else {
+                assertThat(read.getOrThrow()?.model?.javaClass?.name).isEqualTo(WITNESS_NAME)
+                assertThat(harness.loader.events).containsExactly("initialized", "constructed")
+            }
+        }
+    }
+}
+
+data class BaselineModel(val value: String)
+
+internal const val WITNESS_NAME =
+    "de.lise.fluxflow.mongo.security.baseline.fixture.ActivationWitness"

--- a/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/WorkflowModelBaselineTest.kt
+++ b/library/security-tests/src/test/kotlin/de/lise/fluxflow/mongo/security/baseline/WorkflowModelBaselineTest.kt
@@ -30,6 +30,20 @@ class WorkflowModelBaselineTest {
             }
         }
     }
+
+    @Test
+    fun `R04 unrelated root type is ignored while the legitimate model survives`() {
+        MongoSecurityHarness().use { harness ->
+            val identifier = WorkflowIdentifier(UUID.randomUUID().toString())
+            val model = BaselineModel("root report control")
+            harness.workflows.create(model, identifier)
+            assertThat(harness.workflows.find(identifier)?.model).isEqualTo(model)
+            harness.tamper(WorkflowDocument::class.java, identifier.value, "_class", WITNESS_NAME)
+
+            assertThat(harness.workflows.find(identifier)?.model).isEqualTo(model)
+            assertThat(harness.loader.events).isEmpty()
+        }
+    }
 }
 
 data class BaselineModel(val value: String)

--- a/library/springboot/springboot-mongo/build.gradle.kts
+++ b/library/springboot/springboot-mongo/build.gradle.kts
@@ -1,5 +1,15 @@
+import de.lise.fluxflow.gradle.SecurityTestRequirements
+
 plugins {
     id("fluxflow.security-tests")
+}
+
+extensions.configure<SecurityTestRequirements>("securityTests") {
+    requiredClasses.set(listOf(
+        "de.lise.fluxflow.mongo.security.baseline.SecurityWitnessTest",
+        "de.lise.fluxflow.mongo.security.baseline.ActivationBaselineTest",
+        "de.lise.fluxflow.mongo.security.baseline.WorkflowModelBaselineTest",
+    ))
 }
 
 kotlin.sourceSets.named("test") {
@@ -11,6 +21,14 @@ sourceSets.named("test") {
 
 tasks.withType<Test>().configureEach {
     systemProperty("fluxflow.security.expectRejection", providers.gradleProperty("securityExpectRejection").orElse("false").get())
+}
+
+// Boot's dependency-management rules take precedence over a Gradle platform.
+// Keep the Boot 3-compatible Testcontainers line, including its Docker API fix.
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:1.21.4")
+    }
 }
 
 dependencies {
@@ -29,7 +47,6 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-mongodb")
-    testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.5"))
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mongodb")

--- a/library/springboot/springboot-mongo/build.gradle.kts
+++ b/library/springboot/springboot-mongo/build.gradle.kts
@@ -1,3 +1,18 @@
+plugins {
+    id("fluxflow.security-tests")
+}
+
+kotlin.sourceSets.named("test") {
+    kotlin.srcDir("../../security-tests/src/test/kotlin")
+}
+sourceSets.named("test") {
+    java.srcDir("../../security-tests/src/test/java")
+}
+
+tasks.withType<Test>().configureEach {
+    systemProperty("fluxflow.security.expectRejection", providers.gradleProperty("securityExpectRejection").orElse("false").get())
+}
+
 dependencies {
     implementation(kotlin("reflect"))
 
@@ -19,4 +34,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:mongodb")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation(project(":core:engine"))
+    testImplementation(project(":core:stereotyped"))
+    testImplementation(project(":core:validation"))
 }

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/DocumentTypeGuardIT.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/DocumentTypeGuardIT.kt
@@ -2,14 +2,11 @@ package de.lise.fluxflow.mongo.security
 
 import de.lise.fluxflow.api.workflow.WorkflowIdentifier
 import de.lise.fluxflow.mongo.MongoIntegrationTest
-import de.lise.fluxflow.mongo.workflow.WorkflowDocument
 import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Import
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener
 import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
 
@@ -20,33 +17,33 @@ import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
  * (see EventPropagationSpikeTest for the framework-level proof).
  */
 @MongoIntegrationTest
-@Import(DocumentTypeGuardIT.ThrowingListenerConfig::class)
 class DocumentTypeGuardIT {
     @Autowired
     lateinit var workflowPersistence: WorkflowPersistence
+
+    @Autowired
+    lateinit var applicationContext: ConfigurableApplicationContext
 
     @Test
     fun `an exception thrown from onAfterLoad propagates out of a real workflow read`() {
         // Arrange
         val saved = workflowPersistence.create(TestModel("a"), null)
+        val listener = ThrowingDocumentListener()
+        applicationContext.addApplicationListener(listener)
 
         // Act & Assert
-        assertThatThrownBy {
-            workflowPersistence.find(WorkflowIdentifier(saved.id))
-        }.isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("boom")
-    }
-
-    @TestConfiguration
-    class ThrowingListenerConfig {
-        @Bean
-        fun throwingWorkflowDocumentListener(): ThrowingWorkflowDocumentListener {
-            return ThrowingWorkflowDocumentListener()
+        try {
+            assertThatThrownBy {
+                workflowPersistence.find(WorkflowIdentifier(saved.id))
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("boom")
+        } finally {
+            applicationContext.removeApplicationListener(listener)
         }
     }
 
-    class ThrowingWorkflowDocumentListener : AbstractMongoEventListener<WorkflowDocument>() {
-        override fun onAfterLoad(event: AfterLoadEvent<WorkflowDocument>) {
+    class ThrowingDocumentListener : AbstractMongoEventListener<Any>() {
+        override fun onAfterLoad(event: AfterLoadEvent<Any>) {
             throw IllegalStateException("boom")
         }
     }

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/DocumentTypeGuardIT.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/DocumentTypeGuardIT.kt
@@ -1,0 +1,55 @@
+package de.lise.fluxflow.mongo.security
+
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.mongo.MongoIntegrationTest
+import de.lise.fluxflow.mongo.workflow.WorkflowDocument
+import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener
+import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
+
+/**
+ * Proves the load-bearing assumption behind DocumentTypeGuard against a real MongoDB and the real
+ * WorkflowMongoPersistence read path: that a listener's onAfterLoad exception actually reaches the
+ * caller of a normal repository read, not just a hand-built ApplicationContext
+ * (see EventPropagationSpikeTest for the framework-level proof).
+ */
+@MongoIntegrationTest
+@Import(DocumentTypeGuardIT.ThrowingListenerConfig::class)
+class DocumentTypeGuardIT {
+    @Autowired
+    lateinit var workflowPersistence: WorkflowPersistence
+
+    @Test
+    fun `an exception thrown from onAfterLoad propagates out of a real workflow read`() {
+        // Arrange
+        val saved = workflowPersistence.create(TestModel("a"), null)
+
+        // Act & Assert
+        assertThatThrownBy {
+            workflowPersistence.find(WorkflowIdentifier(saved.id))
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("boom")
+    }
+
+    @TestConfiguration
+    class ThrowingListenerConfig {
+        @Bean
+        fun throwingWorkflowDocumentListener(): ThrowingWorkflowDocumentListener {
+            return ThrowingWorkflowDocumentListener()
+        }
+    }
+
+    class ThrowingWorkflowDocumentListener : AbstractMongoEventListener<WorkflowDocument>() {
+        override fun onAfterLoad(event: AfterLoadEvent<WorkflowDocument>) {
+            throw IllegalStateException("boom")
+        }
+    }
+
+    data class TestModel(val value: String)
+}

--- a/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/EventPropagationSpikeTest.kt
+++ b/library/springboot/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/EventPropagationSpikeTest.kt
@@ -1,0 +1,48 @@
+package de.lise.fluxflow.mongo.security
+
+import de.lise.fluxflow.mongo.workflow.WorkflowDocument
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.bson.Document
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.config.BeanDefinitionCustomizer
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener
+import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
+
+/**
+ * Proves the load-bearing assumption behind the whole DocumentTypeGuard approach without needing
+ * MongoDB/Testcontainers: that an exception thrown from AbstractMongoEventListener.onAfterLoad
+ * propagates synchronously out of ApplicationEventPublisher.publishEvent, exactly as
+ * EntityLifecycleEventDelegate.publishEvent (which MongoTemplate delegates to) invokes it.
+ */
+class EventPropagationSpikeTest {
+
+    private class ThrowingListener : AbstractMongoEventListener<WorkflowDocument>() {
+        override fun onAfterLoad(event: AfterLoadEvent<WorkflowDocument>) {
+            throw IllegalStateException("boom")
+        }
+    }
+
+    @Test
+    fun `an exception thrown from onAfterLoad propagates synchronously out of publishEvent`() {
+        // Arrange
+        val context = GenericApplicationContext()
+        // Explicit empty BeanDefinitionCustomizer vararg disambiguates Kotlin's overload
+        // resolution between registerBean's two vararg overloads (constructorArgs vs.
+        // customizers), which are otherwise ambiguous when called with zero arguments.
+        context.registerBean(ThrowingListener::class.java, *arrayOf<BeanDefinitionCustomizer>())
+        context.refresh()
+
+        // Act & Assert
+        try {
+            assertThatThrownBy {
+                context.publishEvent(
+                    AfterLoadEvent(Document(), WorkflowDocument::class.java, "workflowDocument")
+                )
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("boom")
+        } finally {
+            context.close()
+        }
+    }
+}

--- a/library/springboot4/springboot-mongo/build.gradle.kts
+++ b/library/springboot4/springboot-mongo/build.gradle.kts
@@ -1,5 +1,15 @@
+import de.lise.fluxflow.gradle.SecurityTestRequirements
+
 plugins {
     id("fluxflow.security-tests")
+}
+
+extensions.configure<SecurityTestRequirements>("securityTests") {
+    requiredClasses.set(listOf(
+        "de.lise.fluxflow.mongo.security.baseline.SecurityWitnessTest",
+        "de.lise.fluxflow.mongo.security.baseline.ActivationBaselineTest",
+        "de.lise.fluxflow.mongo.security.baseline.WorkflowModelBaselineTest",
+    ))
 }
 
 kotlin.sourceSets.named("test") {
@@ -11,6 +21,12 @@ sourceSets.named("test") {
 
 tasks.withType<Test>().configureEach {
     systemProperty("fluxflow.security.expectRejection", providers.gradleProperty("securityExpectRejection").orElse("false").get())
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.testcontainers:testcontainers-bom:2.0.5")
+    }
 }
 
 kotlin {
@@ -37,7 +53,6 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-mongodb")
-    testImplementation(platform("org.testcontainers:testcontainers-bom:2.0.5"))
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter")
     testImplementation("org.testcontainers:testcontainers-mongodb")

--- a/library/springboot4/springboot-mongo/build.gradle.kts
+++ b/library/springboot4/springboot-mongo/build.gradle.kts
@@ -1,3 +1,18 @@
+plugins {
+    id("fluxflow.security-tests")
+}
+
+kotlin.sourceSets.named("test") {
+    kotlin.srcDir("../../security-tests/src/test/kotlin")
+}
+sourceSets.named("test") {
+    java.srcDir("../../security-tests/src/test/java")
+}
+
+tasks.withType<Test>().configureEach {
+    systemProperty("fluxflow.security.expectRejection", providers.gradleProperty("securityExpectRejection").orElse("false").get())
+}
+
 kotlin {
     sourceSets {
         main {
@@ -29,4 +44,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation(project(":springboot4:springboot"))
     testImplementation(project(":springboot4:springboot-testing"))
+    testImplementation(project(":core:engine"))
+    testImplementation(project(":core:stereotyped"))
+    testImplementation(project(":core:validation"))
 }

--- a/library/springboot4/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/Boot4DocumentTypeGuardIT.kt
+++ b/library/springboot4/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/Boot4DocumentTypeGuardIT.kt
@@ -2,14 +2,11 @@ package de.lise.fluxflow.mongo.security
 
 import de.lise.fluxflow.api.workflow.WorkflowIdentifier
 import de.lise.fluxflow.mongo.Boot4MongoIntegrationTest
-import de.lise.fluxflow.mongo.workflow.WorkflowDocument
 import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Import
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener
 import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
 
@@ -20,33 +17,33 @@ import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
  * version on this line.
  */
 @Boot4MongoIntegrationTest
-@Import(Boot4DocumentTypeGuardIT.ThrowingListenerConfig::class)
 class Boot4DocumentTypeGuardIT {
     @Autowired
     lateinit var workflowPersistence: WorkflowPersistence
+
+    @Autowired
+    lateinit var applicationContext: ConfigurableApplicationContext
 
     @Test
     fun `an exception thrown from onAfterLoad propagates out of a real workflow read`() {
         // Arrange
         val saved = workflowPersistence.create(TestModel("a"), null)
+        val listener = ThrowingDocumentListener()
+        applicationContext.addApplicationListener(listener)
 
         // Act & Assert
-        assertThatThrownBy {
-            workflowPersistence.find(WorkflowIdentifier(saved.id))
-        }.isInstanceOf(IllegalStateException::class.java)
-            .hasMessage("boom")
-    }
-
-    @TestConfiguration
-    class ThrowingListenerConfig {
-        @Bean
-        fun throwingWorkflowDocumentListener(): ThrowingWorkflowDocumentListener {
-            return ThrowingWorkflowDocumentListener()
+        try {
+            assertThatThrownBy {
+                workflowPersistence.find(WorkflowIdentifier(saved.id))
+            }.isInstanceOf(IllegalStateException::class.java)
+                .hasMessage("boom")
+        } finally {
+            applicationContext.removeApplicationListener(listener)
         }
     }
 
-    class ThrowingWorkflowDocumentListener : AbstractMongoEventListener<WorkflowDocument>() {
-        override fun onAfterLoad(event: AfterLoadEvent<WorkflowDocument>) {
+    class ThrowingDocumentListener : AbstractMongoEventListener<Any>() {
+        override fun onAfterLoad(event: AfterLoadEvent<Any>) {
             throw IllegalStateException("boom")
         }
     }

--- a/library/springboot4/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/Boot4DocumentTypeGuardIT.kt
+++ b/library/springboot4/springboot-mongo/src/test/kotlin/de/lise/fluxflow/mongo/security/Boot4DocumentTypeGuardIT.kt
@@ -1,0 +1,55 @@
+package de.lise.fluxflow.mongo.security
+
+import de.lise.fluxflow.api.workflow.WorkflowIdentifier
+import de.lise.fluxflow.mongo.Boot4MongoIntegrationTest
+import de.lise.fluxflow.mongo.workflow.WorkflowDocument
+import de.lise.fluxflow.persistence.workflow.WorkflowPersistence
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener
+import org.springframework.data.mongodb.core.mapping.event.AfterLoadEvent
+
+/**
+ * Mirrors DocumentTypeGuardIT (springboot:springboot-mongo) against spring-data-mongodb 5.x
+ * (Boot 4 line). Only the main sourceSet is shared between the two Boot lines - this spike has to
+ * be proven separately here, since the event/converter machinery underneath is a different major
+ * version on this line.
+ */
+@Boot4MongoIntegrationTest
+@Import(Boot4DocumentTypeGuardIT.ThrowingListenerConfig::class)
+class Boot4DocumentTypeGuardIT {
+    @Autowired
+    lateinit var workflowPersistence: WorkflowPersistence
+
+    @Test
+    fun `an exception thrown from onAfterLoad propagates out of a real workflow read`() {
+        // Arrange
+        val saved = workflowPersistence.create(TestModel("a"), null)
+
+        // Act & Assert
+        assertThatThrownBy {
+            workflowPersistence.find(WorkflowIdentifier(saved.id))
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("boom")
+    }
+
+    @TestConfiguration
+    class ThrowingListenerConfig {
+        @Bean
+        fun throwingWorkflowDocumentListener(): ThrowingWorkflowDocumentListener {
+            return ThrowingWorkflowDocumentListener()
+        }
+    }
+
+    class ThrowingWorkflowDocumentListener : AbstractMongoEventListener<WorkflowDocument>() {
+        override fun onAfterLoad(event: AfterLoadEvent<WorkflowDocument>) {
+            throw IllegalStateException("boom")
+        }
+    }
+
+    data class TestModel(val value: String)
+}


### PR DESCRIPTION
The reported FLUXFLOW-2026-0002 and FLUXFLOW-2026-0003 behaviors did not have mandatory, reproducible regression coverage across the supported Spring Boot lines. This PR adds a shared security baseline that reproduces the relevant activation and Mongo persistence paths before the hardening changes are introduced.

The baseline covers:

- R01/R02 unsafe step and job activation with isolated witness classes
- R03/R04 root and nested Mongo type metadata using a real MongoDB Testcontainer
- R05 isolated class-loading behavior
- mandatory test discovery guards so missing or filtered security tests fail the build
- the same shared scenarios on Spring Boot 3 and Spring Boot 4

The tests intentionally characterize the current behavior. Follow-up PRs can change the production code and invert the affected assertions to prove that each reported gap is closed.

Validation:

```text
.\gradlew.bat :springboot:springboot-mongo:check :springboot4:springboot-mongo:check verifyPublications --continue --console=plain
```

All baseline, Mongo Testcontainer, and publication checks pass without skipped security cases.
